### PR TITLE
Shop-floor time rules, faster boards, idle popups, and backboard QC

### DIFF
--- a/studio-delta-production/Code.gs
+++ b/studio-delta-production/Code.gs
@@ -1,0 +1,2554 @@
+var SHEET_ID = "1pdvAFTIyd5sf8Wbf38MSd4cfk3mb3McPqJrYeM8SOYk"; 
+var TAB_ORDERS = "ORDERS";
+var TAB_USERS = "Users";
+var TAB_LOGS = "Production_Log";
+var TAB_OVERVIEW = "Overview";
+var TAB_RATES = "Rates";
+var FOLDER_NAME = "Studio_Delta_QC_Records";
+var TAB_STEEL_PROFILES = "Steel_Profiles";
+var TAB_STEEL_USAGE = "Steel_Usage";
+
+var TEMP_ID_PRE_POWDER = "18gdKTtaJFqG7EALy-OofLoBxcJ873U4sUTUks3_2oEo";
+var TEMP_ID_FINISHED   = "1WXW4F_PIjcA5v2ZSqJDptQrKtlikiVuqOeUy706rV7I";
+var QC_EMAIL_RECIPIENT = "siyabonga.msiza@studiodelta.co.za,shaka.chabalala@deltabec.com";
+var ALERT_EMAIL_RECIPIENT = "siyabonga.msiza@studiodelta.co.za,shaka.chabalala@deltabec.com";
+var POWDER_FOLDER_NAME = "Studio_Delta_Powder_Lists";
+var POWDER_EMAIL_RECIPIENT = "siyabonga.msiza@studiodelta.co.za";
+var QUEUE_FOLDER_ID = "1MRl3nX7-4d8dmrjQU0UrCbzCf6Ilymub";
+var TAB_IDLE = "Idle_Alerts";
+var TZ_JOBURG = "Africa/Johannesburg";
+var SAST_OFFSET_MS = 2 * 60 * 60 * 1000; // South Africa has no DST
+var STANDARD_DAY_MINS = 8 * 60;
+var IDLE_GRACE_MINS = 10;
+var INDIRECT_TASKS = ["Cleaning", "Maintenance", "Material handling", "Waiting for materials", "Waiting for plate", "Meeting", "Training", "Other"];
+
+// --- STEP 1: CENTRALIZED STEEL PROFILE MANAGEMENT ---
+/**
+ * Returns an array of all steel profile names from the hidden "Steel_Profiles" tab.
+ * If the tab is empty or does not exist, seeds it with the default list and returns that.
+ */
+function getSteelProfiles() {
+  var ss = getSpreadsheet();
+  var sheet = ss.getSheetByName(TAB_STEEL_PROFILES);
+
+  // Create the tab if it does not exist
+  if (!sheet) {
+    sheet = ss.insertSheet(TAB_STEEL_PROFILES);
+    sheet.hideSheet();
+    sheet.appendRow(["Category", "Profile Name"]); // Header
+    return[];
+  }
+
+  // Read existing profiles
+  var data = sheet.getDataRange().getValues();
+  if (data.length <= 1) {
+    return[];
+  }
+
+  // Skip header row (index 0), return the values as objects
+  var profiles =[];
+  for (var i = 1; i < data.length; i++) {
+    var cat = String(data[i][0]).trim();
+    var name = String(data[i][1]).trim();
+    
+    // Handle legacy 1-column setup gracefully if you have any old rows left
+    if (!name && cat) {
+        name = cat;
+        cat = "Uncategorized";
+    }
+    if (name) profiles.push({ category: cat, name: name });
+  }
+  return profiles;
+}
+
+function doGet() {
+  try { ensureIdleTrigger(); } catch (e) {}
+  return HtmlService.createTemplateFromFile('index')
+    .evaluate()
+    .setTitle('Studio Delta Production')
+    .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL)
+    .addMetaTag('viewport', 'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0'); 
+}
+
+function getSpreadsheet() {
+  if (SHEET_ID && SHEET_ID !== "1pdvAFTIyd5sf8Wbf38MSd4cfk3mb3McPqJrYeM8SOYk") {
+    return SpreadsheetApp.openById(SHEET_ID);
+  }
+  
+  return SpreadsheetApp.getActiveSpreadsheet();
+}
+
+function getSheetOrDie(ss, tabName) {
+  var sheet = ss.getSheetByName(tabName);
+  if (!sheet) throw new Error("Missing Tab: '" + tabName + "'. Please create it.");
+  return sheet;
+}
+
+function getPlateCuttingStatus(ss, orderNum) {
+  var logSheet = getSheetOrDie(ss, TAB_LOGS);
+  var logData = logSheet.getDataRange().getValues();
+  
+  // Loop backwards to find the most recent entry
+  for (var i = logData.length - 1; i >= 1; i--) { 
+    var logOrderNum = logData[i][1]; 
+    var logRole = logData[i][3]; 
+    var logWorker = logData[i][2]; 
+    var logEndTime = logData[i][6]; 
+    var meta = parseLogMeta(logData[i].length > 12 ? logData[i][12] : "");
+    var pauseStart = getOpenPauseStart(meta) || logData[i][9];
+    var pauseReason = "";
+    if (meta.pauses && meta.pauses.length) pauseReason = meta.pauses[meta.pauses.length - 1].reason || "";
+    if (!pauseReason) pauseReason = logData[i].length > 11 ? logData[i][11] : "";
+
+    if (String(logOrderNum) == String(orderNum) && String(logRole).trim() === 'Plate Cutting') {
+      if (!logEndTime) {
+        return {
+          status: 'Plate Cutting',
+          assigned: logWorker,
+          isPaused: !!pauseStart,
+          pauseReason: pauseReason || "",
+          logId: logData[i][0],
+          batchId: meta.batchId || "",
+          isBatched: !!(meta.batchId && !meta.batchSplitAt && (meta.batchShare || 1) > 1)
+        };
+      } else {
+        return {status: 'Finished', assigned: '', isPaused: false, pauseReason: "", logId: "", batchId: "", isBatched: false};
+      }
+    }
+  }
+  
+  return {status: '', assigned: '', isPaused: false, pauseReason: "", logId: "", batchId: "", isBatched: false}; 
+}
+
+function setPlateCuttingStatus(ss, orderNum, status, worker) {
+  // This function doesn't need to do anything because plate cutting status
+  // is automatically derived from Production_Log entries.
+  // The status is set when a log entry is created in startOrder().
+  // We keep this function for compatibility but it's a no-op.
+  return;
+}
+
+function clearPlateCuttingStatus(ss, orderNum) {
+  // This function doesn't need to do anything because plate cutting completion
+  // is automatically tracked when the log entry's end time is set in finishOrder().
+  // We keep this function for compatibility but it's a no-op.
+  return;
+}
+
+// --- CORE: USERS & LOGIN ---
+function getUsersAndRoles() {
+  var ss = getSpreadsheet();
+  var sheet = getSheetOrDie(ss, TAB_USERS); 
+  var data = sheet.getDataRange().getValues();
+  if (data.length <= 1) return []; 
+  data.shift(); // Remove header
+  return data.map(function(row) { return { name: row[0], role: row[1] }; });
+}
+
+// Helper function for case-insensitive status comparison
+function includesStatusCaseInsensitive(statusArray, statusToCheck) {
+  if (!statusToCheck) return false;
+  var lowerStatus = String(statusToCheck).toLowerCase().trim();
+  for (var i = 0; i < statusArray.length; i++) {
+    if (String(statusArray[i]).toLowerCase().trim() === lowerStatus) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function verifyLogin(role, name, password) {
+  var ss = getSpreadsheet();
+  var sheet = getSheetOrDie(ss, TAB_USERS);
+  var data = sheet.getDataRange().getValues();
+  
+  // 1. Find the Admin Password first (Master Key)
+  var adminPassword = null;
+  for (var i = 1; i < data.length; i++) {
+    if (String(data[i][1]).toLowerCase() === 'admin') {
+      adminPassword = data[i][2];
+      break;
+    }
+  }
+
+  // 2. Check Credentials
+  for (var i = 1; i < data.length; i++) {
+    var rowName = data[i][0];
+    var rowRole = data[i][1];
+    var rowPass = data[i][2];
+
+    // Target Match
+    if (role === rowRole && name === rowName) {
+      
+      // A. Normal User Login
+      if (String(password) == String(rowPass)) {
+        var isAdmin = (role === 'Admin'); 
+        return { success: true, isAdmin: isAdmin };
+      }
+      
+      // B. Admin "Master Key" Login (Admin logging into a Worker profile)
+      if (adminPassword && String(password) == String(adminPassword)) {
+        return { success: true, isAdmin: true }; // Grants Read-Only access in UI
+      }
+    }
+  }
+  
+  return { success: false, error: "Incorrect Access Code" };
+}
+
+function verifyGlobalLogin(name, password) {
+  var ss = getSpreadsheet();
+  var sheet = getSheetOrDie(ss, TAB_USERS);
+  var data = sheet.getDataRange().getValues();
+  
+  // 1. Find the Admin Password first (Master Key)
+  var adminPassword = null;
+  for (var i = 1; i < data.length; i++) {
+    if (String(data[i][1]).toLowerCase() === 'admin') {
+      adminPassword = data[i][2];
+      break;
+    }
+  }
+
+  // 2. Check Credentials (case-insensitive name match)
+  var lowerName = String(name).trim().toLowerCase();
+  for (var i = 1; i < data.length; i++) {
+    var rowName = String(data[i][0]).trim().toLowerCase();
+    var rowPass = data[i][2];
+
+    if (lowerName === rowName && rowName !== "") {
+      if (String(password) == String(rowPass)) {
+        return { success: true };
+      }
+      if (adminPassword && String(password) == String(adminPassword)) {
+        return { success: true };
+      }
+    }
+  }
+  
+  return { success: false, error: "Incorrect Name or Access Code" };
+}
+
+function getOrdersForRole(role, workerName) {
+  var ss = getSpreadsheet();
+  var sheet = getSheetOrDie(ss, TAB_ORDERS);
+  var data = sheet.getDataRange().getValues();
+  
+  var activeAssignments = getActiveAssignments(ss);
+  var relevantOrders = [];
+  
+  var mainVisibilityMap = {
+    'Profile Cutting': ['Not Yet Started', 'Ready for Steelwork', 'Profile Cutting'],
+    'Tagging': ['Ready for Tagging', 'Tagging'],
+    'Welding': ['Ready for Welding', 'Welding'],
+    'Grinding': ['Ready for Grinding', 'Grinding'],
+    'Quality Control': [
+      'Ready for Pre-Powder Coating', 'Pre-Powder Coating', 
+      'Ready for Powder Coating', 'Powder Coating', 
+      'Ready for Final QC', 'Final QC',
+      'Ready for Delivery', 'Out for Delivery'
+    ],
+    'Assembly': ['Ready for Assembly', 'Assembly']
+  };
+
+  var plateCuttingStages = [
+    'not yet started', 
+    'ready for steelwork', 'profile cutting', 
+    'ready for tagging', 'tagging', 
+    'ready for welding', 'welding'
+  ];
+
+  for (var i = 1; i < data.length; i++) {
+    var orderNum = data[i][1];             
+    var mainStatusRaw = data[i][2];        
+    var mainStatus = String(mainStatusRaw).trim(); 
+    var mainStatusLower = mainStatus.toLowerCase();
+    var productName = data[i][6];
+
+    if (!isAllowedStatus(mainStatus)) continue;
+
+    var assignment = activeAssignments[orderNum];
+    var assignedWorker = assignment ? assignment.worker : ""; 
+    var isPaused = assignment ? assignment.isPaused : false;
+    var pauseReason = assignment ? assignment.pauseReason : "";
+    var logId = assignment ? assignment.logId : "";
+    var batchId = assignment ? assignment.batchId : "";
+    var isBatched = assignment ? assignment.isBatched : false;
+
+    if (role === 'Plate Cutting') {
+      var plateInfo = getPlateCuttingStatus(ss, orderNum); 
+      var isStageValid = plateCuttingStages.indexOf(mainStatusLower) > -1;
+      var isAlreadyActive = plateInfo.status === 'Plate Cutting';
+      var isNotFinished = plateInfo.status !== 'Finished';
+
+      if ((isStageValid || isAlreadyActive) && isNotFinished) {
+        relevantOrders.push({
+          rowIndex: i + 1,
+          order: orderNum,
+          productName: productName,
+          status: isAlreadyActive ? 'In Progress' : 'Available',
+          assigned: plateInfo.assigned,
+          isPaused: plateInfo.isPaused,
+          pauseReason: plateInfo.pauseReason,
+          isPlateOrder: true,
+          logId: plateInfo.logId || "",
+          batchId: plateInfo.batchId || "",
+          isBatched: !!plateInfo.isBatched
+        });
+      }
+      continue; 
+    }
+
+    var allowedStatuses = mainVisibilityMap[role] ||[];
+    
+    if (role === 'Admin' || includesStatusCaseInsensitive(allowedStatuses, mainStatus)) {
+      relevantOrders.push({
+        rowIndex: i + 1,
+        order: orderNum,
+        productName: productName,
+        status: mainStatus,
+        assigned: assignedWorker, 
+        isPaused: isPaused,
+        pauseReason: pauseReason,
+        isPlateOrder: false,
+        logId: logId || "",
+        batchId: batchId || "",
+        isBatched: !!isBatched
+      });
+    }
+  }
+  return relevantOrders;
+}
+
+function startOrder(rowIndex, workerName, role, batchRowIndices) {
+  var lock = LockService.getScriptLock();
+  lock.waitLock(10000); 
+  
+  try {
+    var ss = getSpreadsheet();
+    var sheet = getSheetOrDie(ss, TAB_ORDERS);
+    var logSheet = getSheetOrDie(ss, TAB_LOGS);
+    var overviewSheet = ss.getSheetByName(TAB_OVERVIEW);
+
+    var rowsToStart = [];
+    if (batchRowIndices && batchRowIndices.length) {
+      for (var b = 0; b < batchRowIndices.length; b++) {
+        var br = parseInt(batchRowIndices[b], 10);
+        if (rowsToStart.indexOf(br) === -1) rowsToStart.push(br);
+      }
+    }
+    if (rowsToStart.indexOf(parseInt(rowIndex, 10)) === -1) {
+      rowsToStart.unshift(parseInt(rowIndex, 10));
+    }
+
+    closeIndirectTasksForWorker(ss, workerName);
+
+    var batchId = rowsToStart.length > 1 ? Utilities.getUuid() : "";
+    var batchShare = rowsToStart.length > 1 ? rowsToStart.length : 1;
+    var exceptOrders = [];
+    for (var e = 0; e < rowsToStart.length; e++) {
+      exceptOrders.push(sheet.getRange(rowsToStart[e], 2).getValue());
+    }
+
+    var pauseReason = (role === "Welding")
+      ? ("Waiting for plate / switched to " + exceptOrders[0])
+      : ("Switched to order " + exceptOrders[0]);
+    autoPauseWorkerOtherJobs(ss, workerName, exceptOrders, pauseReason, batchId);
+
+    var started = [];
+    var startTime = new Date();
+
+    for (var r = 0; r < rowsToStart.length; r++) {
+      var thisRow = rowsToStart[r];
+      var orderNum = sheet.getRange(thisRow, 2).getValue();
+      var currentStatus = sheet.getRange(thisRow, 3).getValue();
+
+      var nextStatus = "";
+      if (role === 'Plate Cutting') {
+        nextStatus = "Plate Cutting";
+      } else {
+        nextStatus = getNextStatus(currentStatus);
+        if (nextStatus && nextStatus.startsWith("Ready")) {
+          while (nextStatus && nextStatus.startsWith("Ready")) { 
+            var temp = getNextStatus(nextStatus); 
+            if (!temp) break; 
+            nextStatus = temp;
+          }
+        }
+      }
+
+      if (role === 'Plate Cutting') {
+        var plateInfo = getPlateCuttingStatus(ss, orderNum);
+        if (plateInfo.assigned !== "" && plateInfo.assigned !== workerName) {
+          throw new Error("Plate Cutting is already being done by " + plateInfo.assigned);
+        }
+        if (plateInfo.assigned === workerName) {
+          started.push({ order: orderNum, rowIndex: thisRow, logId: plateInfo.logId, newStatus: nextStatus });
+          continue;
+        }
+      } else {
+        var activeAssignments = getActiveAssignments(ss); 
+        var currentAssignment = activeAssignments[orderNum];
+        var currentAssigned = currentAssignment ? currentAssignment.worker : ""; 
+        if (currentAssigned !== "" && currentAssigned !== workerName) {
+          throw new Error("Order locked by " + currentAssigned);
+        }
+        if (currentAssigned === workerName && currentAssignment && !currentAssignment.isPaused) {
+          started.push({ order: orderNum, rowIndex: thisRow, logId: currentAssignment.logId, newStatus: currentStatus });
+          continue;
+        }
+        if (currentAssigned === workerName && currentAssignment && currentAssignment.isPaused) {
+          resumeWorkerLog(ss, workerName, orderNum);
+          started.push({ order: orderNum, rowIndex: thisRow, logId: currentAssignment.logId, newStatus: currentStatus, resumed: true });
+          continue;
+        }
+      }
+
+      var uniqueId = Utilities.getUuid();
+      var meta = defaultLogMeta();
+      meta.batchId = batchId;
+      meta.batchShare = batchShare;
+      meta.entryType = "production";
+
+      if (role !== 'Plate Cutting') {
+        sheet.getRange(thisRow, 3).setValue(nextStatus); 
+        sheet.getRange(thisRow, 4).setValue(workerName); 
+      }
+
+      logSheet.appendRow([
+        uniqueId, orderNum, workerName, role, nextStatus, startTime, "", "", "",
+        "", "", "", JSON.stringify(meta)
+      ]);
+
+      if (overviewSheet) {
+        overviewSheet.appendRow([uniqueId, orderNum, workerName, nextStatus, startTime, "", ""]);
+      }
+
+      started.push({ order: orderNum, rowIndex: thisRow, logId: uniqueId, newStatus: nextStatus });
+    }
+    
+    SpreadsheetApp.flush();
+    return {
+      success: true,
+      newStatus: started[0] ? started[0].newStatus : "",
+      logId: started[0] ? started[0].logId : "",
+      started: started,
+      batchId: batchId
+    };
+    
+  } finally {
+    lock.releaseLock();
+  }
+}
+
+// STEP 2: Added steelUsageData as the 7th parameter. orderNumHint is 8th (optional).
+function finishOrder(rowIndex, logId, qcData, signatureUrl, filesData, workerName, steelUsageData, orderNumHint) {
+  var lock = LockService.getScriptLock();
+  lock.waitLock(120000); 
+  
+  try {
+    var ss = getSpreadsheet();
+    var sheet = getSheetOrDie(ss, TAB_ORDERS);
+    var logSheet = getSheetOrDie(ss, TAB_LOGS);
+    var overviewSheet = ss.getSheetByName(TAB_OVERVIEW);
+    var endTime = new Date(); 
+    
+    var logs = logSheet.getDataRange().getValues();
+    var orderNum = orderNumHint || sheet.getRange(rowIndex, 2).getValue();
+    var rowToUpdate = findOpenLogRow(logs, logId, orderNum, workerName);
+    
+    if (rowToUpdate === -1) {
+      throw new Error("Could not find active log entry for " + workerName + " on this order.");
+    }
+
+    var logRow = logs[rowToUpdate-1];
+    var role = logRow[3];
+    var processName = logRow[4];
+    var startTime = logRow[5] ? new Date(logRow[5]) : null;
+    orderNum = logRow[1];
+    var meta = parseLogMeta(logRow.length > 12 ? logRow[12] : "");
+
+    var trueRow = findOrderRowByNumber(sheet, orderNum);
+    if (trueRow > 0) rowIndex = trueRow;
+
+    if (role === 'Quality Control') {
+      var procLower = String(processName).trim().toLowerCase();
+      if (procLower !== 'powder coating' && procLower !== 'out for delivery') {
+        if (!qcData || qcData.length === 0) {
+          throw new Error("Server rejected: Incomplete QC answers. Please answer all checklist questions.");
+        }
+        if (!signatureUrl) {
+          throw new Error("Server rejected: A signature is required to complete Quality Control.");
+        }
+      }
+    }
+    if (role === 'Profile Cutting' || role === 'Plate Cutting') {
+      if (!steelUsageData || steelUsageData.length === 0) {
+        throw new Error("Server rejected: Steel material usage must be logged before finishing " + role + ".");
+      }
+    }
+
+    meta = closeOpenPauseInMeta(meta, endTime);
+    if (meta.batchId && !meta.batchSplitAt) {
+      meta.batchSplitAt = endTime.getTime();
+    }
+
+    if(role === 'Plate Cutting') {
+        // Plate Cutting Finished -> Do NOT change Order Status
+    } else {
+        var nextStep = getNextStatus(processName || sheet.getRange(rowIndex, 3).getValue()); 
+        sheet.getRange(rowIndex, 3).setValue(nextStep);
+        sheet.getRange(rowIndex, 4).setValue("");
+    }
+
+    if (steelUsageData && steelUsageData.length > 0) {
+      var usageSheet = ss.getSheetByName(TAB_STEEL_USAGE);
+      if (!usageSheet) {
+        usageSheet = ss.insertSheet(TAB_STEEL_USAGE);
+        usageSheet.hideSheet();
+        usageSheet.appendRow(["Timestamp", "Order #", "Worker", "Process", "Profile Type", "Size / Length"]);
+      }
+
+      var profilesSheet = ss.getSheetByName(TAB_STEEL_PROFILES);
+      if (!profilesSheet) {
+        getSteelProfiles();
+        profilesSheet = ss.getSheetByName(TAB_STEEL_PROFILES);
+      }
+      var existingProfileData = profilesSheet ? profilesSheet.getDataRange().getValues() : [];
+      var existingProfileNames =[];
+      for (var p = 1; p < existingProfileData.length; p++) {
+        var pv = String(existingProfileData[p][1] || existingProfileData[p][0]).trim().toLowerCase();
+        if (pv) existingProfileNames.push(pv);
+      }
+
+      steelUsageData.forEach(function(item) {
+        var usageName = item.category && item.category !== 'Uncategorized' ? (item.category + " - " + item.type) : item.type;
+        usageSheet.appendRow([
+          new Date(),
+          orderNum,
+          workerName,
+          processName,
+          usageName,
+          item.size
+        ]);
+
+        if (item.isCustom && profilesSheet) {
+          var newProfileLower = String(item.type).trim().toLowerCase();
+          if (newProfileLower && existingProfileNames.indexOf(newProfileLower) === -1) {
+            profilesSheet.appendRow([item.category || "Custom", String(item.type).trim()]);
+            existingProfileNames.push(newProfileLower);
+          }
+        }
+      });
+    }
+
+    var resultStr = qcData ? qcData.map(function(i){return i.q+": "+i.a}).join("\n") : "Complete";
+    logSheet.getRange(rowToUpdate, 7).setValue(endTime);
+    logSheet.getRange(rowToUpdate, 8).setValue(resultStr);
+    if(signatureUrl) logSheet.getRange(rowToUpdate, 9).setValue(signatureUrl);
+    writeLogMeta(logSheet, rowToUpdate, meta);
+    syncLegacyPauseCells(logSheet, rowToUpdate, meta, processName);
+
+    SpreadsheetApp.flush();
+
+    var switched = [];
+    if (role === 'Plate Cutting') {
+      switched = autoSwitchWeldersAfterPlate(ss, orderNum);
+    }
+
+    if (role === 'Quality Control' && qcData && signatureUrl && processName !== 'Powder Coating') {
+        try {
+            var jobData = {
+                logId: logRow[0],
+                qcData: qcData,
+                signatureUrl: signatureUrl,
+                filesData: filesData,
+                workerName: workerName,
+                orderNum: orderNum, 
+                processName: processName,
+                rowToUpdate: rowToUpdate
+            };
+            
+            var queueFolder = DriveApp.getFolderById(QUEUE_FOLDER_ID);
+            var fileName = "JOB_" + new Date().getTime() + "_" + jobData.orderNum + ".json";
+            queueFolder.createFile(fileName, JSON.stringify(jobData), MimeType.PLAIN_TEXT);
+
+        } catch (e) {
+            logSheet.getRange(rowToUpdate, 8).setValue(resultStr + "\n\nError adding to PDF Queue: " + e.toString());
+        }
+    }
+
+    if (overviewSheet) {
+      var ovData = overviewSheet.getDataRange().getValues();
+      var ovRow = -1;
+      for (var k = ovData.length - 1; k >= 0; k--) {
+         if (ovData[k][1] == orderNum && 
+             ovData[k][3] == processName && 
+             ovData[k][5] === "") {
+            ovRow = k + 1;
+            break;
+         }
+      }
+
+      if (ovRow > 0) {
+        var finishedRow = logSheet.getRange(rowToUpdate, 1, 1, 13).getValues()[0];
+        var durationMins = calculateWorkMinutesFromLog(finishedRow);
+        var durationStr = formatDurationServer(durationMins);
+        overviewSheet.getRange(ovRow, 6).setValue(endTime); 
+        overviewSheet.getRange(ovRow, 7).setValue(durationStr);
+      }
+    }
+    
+    return { success: true, switched: switched };
+    
+  } catch(e) {
+    return { success: false, error: e.toString() };
+  } finally {
+    try { lock.releaseLock(); } catch (ignore) {}
+  }
+}
+
+function logWelderSteel(orderNum, workerName, item) {
+  var lock = LockService.getScriptLock();
+  lock.waitLock(30000); 
+  try {
+    var ss = getSpreadsheet();
+    var usageSheet = ss.getSheetByName(TAB_STEEL_USAGE);
+    if (!usageSheet) {
+      usageSheet = ss.insertSheet(TAB_STEEL_USAGE);
+      usageSheet.hideSheet();
+      usageSheet.appendRow(["Timestamp", "Order #", "Worker", "Process", "Profile Type", "Size / Length"]);
+    }
+
+    var profilesSheet = ss.getSheetByName(TAB_STEEL_PROFILES);
+    if (!profilesSheet) {
+      getSteelProfiles(); // This seeds the sheet on first call
+      profilesSheet = ss.getSheetByName(TAB_STEEL_PROFILES);
+    }
+    
+    var existingProfileData = profilesSheet ? profilesSheet.getDataRange().getValues() : [];
+    var existingProfileNames = [];
+    for (var p = 1; p < existingProfileData.length; p++) {
+      var pv = String(existingProfileData[p][1] || existingProfileData[p][0]).trim().toLowerCase();
+      if (pv) existingProfileNames.push(pv);
+    }
+
+    var usageName = item.category && item.category !== 'Uncategorized' ? (item.category + " - " + item.type) : item.type;
+    
+    usageSheet.appendRow([
+      new Date(),
+      orderNum,
+      workerName,
+      "Welding", // Explicitly log this as the Welding process
+      usageName,
+      item.size
+    ]);
+
+    if (item.isCustom && profilesSheet) {
+      var newProfileLower = String(item.type).trim().toLowerCase();
+      if (newProfileLower && existingProfileNames.indexOf(newProfileLower) === -1) {
+        profilesSheet.appendRow([item.category || "Custom", String(item.type).trim()]);
+      }
+    }
+    SpreadsheetApp.flush(); 
+    return { success: true };
+  } catch(e) {
+    return { success: false, error: e.toString() };
+  } finally {
+    lock.releaseLock();
+  }
+}
+
+// --- NEW FUNCTION: Fetch Only Welding Orders ---
+function getWeldingOrders() {
+  var ss = getSpreadsheet();
+  var sheet = getSheetOrDie(ss, TAB_ORDERS);
+  var data = sheet.getDataRange().getValues();
+  var weldingOrders = [];
+  
+  // Available to Welders = "Ready for Welding"
+  // In Progress for Welders = "Welding"
+  var validStatuses = ['ready for welding', 'welding'];
+
+  for (var i = 1; i < data.length; i++) {
+    var orderNum = data[i][1];
+    var mainStatusRaw = data[i][2];
+    var mainStatusLower = String(mainStatusRaw).trim().toLowerCase();
+    var productName = data[i][6];
+
+    // If the order is currently at the Welder stage, grab it
+    if (validStatuses.indexOf(mainStatusLower) > -1) {
+      weldingOrders.push({
+        order: orderNum,
+        productName: productName
+      });
+    }
+  }
+  return weldingOrders;
+}
+
+function generateQCPdf(templateId, orderNum, workerName, qcAnswers, sigBase64, photos, shouldEmail) {
+  // Default shouldEmail to true if not provided (backward compatibility)
+  if (shouldEmail === undefined) {
+    shouldEmail = true;
+  }
+  
+  var folder = getFolder();
+  var templateFile = DriveApp.getFileById(templateId);
+  
+  var qcType = (templateId === TEMP_ID_FINISHED) ? "Final QC" : "Pre-powder coating QC";
+  var exactFileName = orderNum + "_" + qcType;
+  
+  var newFile = templateFile.makeCopy(exactFileName, folder);
+  var doc = DocumentApp.openById(newFile.getId());
+  var body = doc.getBody();
+
+  // 1. Text Replacements
+  body.replaceText("{{WorkerName}}", workerName);
+  body.replaceText("{{Timestamp}}", new Date().toLocaleString());
+  body.replaceText("{{OrderNumber}}", orderNum);
+
+  // 2. Answer Replacements (Y/N -> Yes/No)
+  if (qcAnswers) {
+    for (var i = 0; i < qcAnswers.length; i++) {
+      var answerRaw = qcAnswers[i].a;
+      var answerFormatted = answerRaw;
+      if (answerRaw === "Y") answerFormatted = "Yes";
+      if (answerRaw === "N") answerFormatted = "No";
+      body.replaceText("{{Q" + (i+1) + "}}", answerFormatted);
+    }
+  }
+
+  
+  function replaceImageTagWithHeader(tag, base64Data, isOptional, displayName) {
+    var r = body.findText(tag);
+    if (r) {
+      var element = r.getElement();
+      var parent = element.getParent();
+      
+      // Clean up header text
+      var headerText = displayName;
+      if (!headerText) {
+        headerText = tag.replace("{{Image_", "").replace("}}", "").replace("{{", "").replace("}}", "");
+        headerText = headerText.replace(/([A-Z])/g, ' $1').trim();
+      }
+
+      if (base64Data) {
+        // 1. INSERT PAGE BREAK
+        // This gives the photo a full page to occupy
+        try {
+          var parentIndex = body.getChildIndex(parent);
+          if (parentIndex > 0) {
+            body.insertPageBreak(parentIndex);
+          }
+        } catch(e) {}
+
+        // 2. SET HEADER TEXT
+        var text = element.asText();
+        text.setText(headerText + "\r"); 
+        text.setBold(true);
+        text.setFontSize(16); // Nice big header
+
+        // 3. INSERT IMAGE
+        var imgBlob = Utilities.newBlob(Utilities.base64Decode(base64Data), 'image/jpeg');
+        var img = parent.insertInlineImage(parent.getChildIndex(element)+1, imgBlob);
+        
+        // 4. "ASPECT RATIO PRESERVATION" LOGIC
+        try {
+          // A. Get the original size from the image itself
+          var origW = img.getWidth();
+          var origH = img.getHeight();
+          var aspectRatio = origW / origH; // Example: 1.77 (Landscape) or 0.56 (Portrait)
+
+          // B. Define the "Safe Box" for an A4 page (minus margins)
+          // 540 points is roughly the max width for standard margins
+          // 720 points is roughly the max height for standard margins + header
+          var MAX_WIDTH = 540;  
+          var MAX_HEIGHT = 720; 
+
+          // C. Calculate target dimensions
+          // First, try to fill the Width
+          var finalW = MAX_WIDTH;
+          var finalH = finalW / aspectRatio;
+
+          // D. Check for Overflow
+          // If filling the width makes the image too tall (Portrait issue), 
+          // we switch strategy and fill the Height instead.
+          if (finalH > MAX_HEIGHT) {
+             finalH = MAX_HEIGHT;
+             finalW = finalH * aspectRatio; // Calculate width based on height
+          }
+
+          // E. Apply Calculated Dimensions
+          // Since finalW and finalH are linked by the aspectRatio, 
+          // STRETCHING IS MATHEMATICALLY IMPOSSIBLE here.
+          img.setWidth(finalW);
+          img.setHeight(finalH);
+          
+        } catch (e) {
+          // Fallback only if image data is corrupt (rare)
+          img.setWidth(500); // Sets width, leaves height auto
+        }
+
+      } else if (!isOptional) {
+        // Required photo missing
+        element.asText().setText(headerText + ": No photo provided");
+        element.asText().setBold(false);
+      } else {
+        // Optional photo missing
+        parent.removeChild(element);
+      }
+    }
+  }
+
+  // 3. Signature (Special handling for size)
+  var sigTag = "{{Signature}}";
+  var sigRange = body.findText(sigTag);
+  if (sigRange) {
+      var sigElem = sigRange.getElement();
+      var sigParent = sigElem.getParent();
+      
+      // Set Header
+      sigElem.asText().setText("Signature\r");
+      sigElem.asText().setBold(true);
+
+      if (sigBase64) {
+        // Note: Signature from canvas usually has "data:image/png;base64," prefix, we must strip it
+        var cleanSig = sigBase64.split(',')[1];
+        var sigBlob = Utilities.newBlob(Utilities.base64Decode(cleanSig), 'image/png');
+        
+        var sigImg = sigParent.insertInlineImage(sigParent.getChildIndex(sigElem)+1, sigBlob);
+        sigImg.setWidth(200).setHeight(100); // Keep signature smaller/rectangular
+      } else {
+        sigElem.asText().setText("Signature: Not signed");
+      }
+  }
+
+  // 4. Process Photos using the new Helper
+  // Pre-Powder Coating Template: Front, Left Side, Right Side, Back, Open, Top (optional), Level 1, Level 2 (optional)
+  var mapPre = [
+    {tag: "{{Image_Front}}", name: "Front", optional: false},
+    {tag: "{{Image_LeftSide}}", name: "Left Side", optional: false},
+    {tag: "{{Image_RightSide}}", name: "Right Side", optional: false},
+    {tag: "{{Image_Back}}", name: "Back", optional: false},
+    {tag: "{{Image_Open}}", name: "Open", optional: false},
+    {tag: "{{Image_Top}}", name: "Top", optional: true},
+    {tag: "{{Image_Level1}}", name: "Level 1", optional: false},
+    {tag: "{{Image_Level2}}", name: "Level 2", optional: true}
+  ];
+  
+  // Finished Goods Template: Front, Level 1, Back, Left Side, Right Side, Job Card, Open, Top (optional), Level 2 (optional)
+  var mapFin = [
+    {tag: "{{Image_Front}}", name: "Front", optional: false},
+    {tag: "{{Image_Level1}}", name: "Level 1", optional: false},
+    {tag: "{{Image_Back}}", name: "Back", optional: false},
+    {tag: "{{Image_LeftSide}}", name: "Left Side", optional: false},
+    {tag: "{{Image_RightSide}}", name: "Right Side", optional: false},
+    {tag: "{{Image_Card}}", name: "Job Card", optional: false},
+    {tag: "{{Image_Open}}", name: "Open", optional: false},
+    {tag: "{{Image_Top}}", name: "Top", optional: true},
+    {tag: "{{Image_Level2}}", name: "Level 2", optional: true}
+  ];
+  
+  // Detect which template is being used based on tags present
+  var useMap = body.findText("{{Image_Card}}") ? mapFin : mapPre;
+
+  // Note: The photos array includes null entries for skipped optional photos
+  // The array length matches the number of photo inputs, with null representing skipped optional photos
+  for (var j = 0; j < useMap.length; j++) {
+    var photoData = null;
+    if (photos && j < photos.length && photos[j] !== null) {
+      photoData = photos[j].data;
+    }
+    replaceImageTagWithHeader(useMap[j].tag, photoData, useMap[j].optional, useMap[j].name);
+  }
+
+  doc.saveAndClose();
+  
+  // Convert to PDF
+  var pdfBlob = newFile.getAs('application/pdf');
+  var pdfFile = folder.createFile(pdfBlob);
+  
+  // Trash the temp doc
+  newFile.setTrashed(true);
+
+  // --- EMAIL SECTION ---
+  if (shouldEmail && QC_EMAIL_RECIPIENT && QC_EMAIL_RECIPIENT.trim() !== "") {
+    try {
+      // Clean, trim whitespace, and parse email addresses into an array
+      var emailList = QC_EMAIL_RECIPIENT.split(",")
+        .map(function(email) { return email.trim(); })
+        .filter(function(email) { return email.length > 0; });
+
+      if (emailList.length > 0) {
+        var mainRecipient = emailList[0]; // First email gets 'TO'
+        var ccRecipients = emailList.slice(1).join(","); // All remaining emails get 'CC'
+
+        var emailOptions = {
+          to: mainRecipient,
+          subject: "QC Report: " + orderNum + " (" + workerName + ")",
+          htmlBody: "<p>Please find the attached QC report for Order <strong>" + orderNum + "</strong>.</p>" +
+                    "<p>Completed by: " + workerName + "<br>Date: " + new Date().toLocaleString() + "</p>",
+          attachments: [pdfBlob]
+        };
+
+        // Attach CC list if additional recipients exist
+        if (ccRecipients.length > 0) {
+          emailOptions.cc = ccRecipients;
+        }
+
+        MailApp.sendEmail(emailOptions);
+      }
+    } catch (e) {
+      Logger.log("QC Email failed: " + e.toString());
+    }
+  }
+  
+  return pdfFile.getUrl();
+}
+
+function getFolder() {
+  // Forces the system to use YOUR exact folder ID going forward
+  return DriveApp.getFolderById("1pyzJ-jcgltJlrCOwjR7c8AIFxwcd2YcK");
+}
+// --- CALCULATION LOGIC ---
+// --- CALCULATION LOGIC ---
+function calculateWorkMinutesServer(start, end, taskName, pausedMins, pauseStart) {
+  if (!start) return 0;
+  var meta = defaultLogMeta();
+  if (pauseStart) {
+    meta.pauses.push({
+      start: new Date(pauseStart).getTime(),
+      end: end ? new Date(end).getTime() : null,
+      reason: ""
+    });
+    return calculateWorkMinutesMeta(start, end, taskName, meta, 0);
+  }
+  var actualEnd = end ? end : new Date();
+  var rawMins = calcRawServerMins(start, actualEnd, taskName);
+  var pMins = parseFloat(pausedMins) || 0;
+  var finalMins = rawMins - pMins;
+  return finalMins > 0 ? finalMins : 0;
+}
+
+function calcRawServerMins(start, end, taskName) {
+  if (!start || !end) return 0;
+  if (taskName && String(taskName).trim() === 'Powder Coating') {
+    return (end.getTime() - start.getTime()) / 1000 / 60;
+  }
+
+  var SHIFT_START_MINS = 7 * 60 + 30;
+  var LUNCH_START_MINS = 12 * 60;
+  var LUNCH_END_MINS   = 13 * 60;
+  var SHIFT_END_MINS   = 15 * 60 + 45;
+  var SHIFT_DURATION   = 435;
+
+  function getWorkingMins(startDate, endDate) {
+     var sMins = sastMinsOfDay(startDate);
+     var eMins = sastMinsOfDay(endDate);
+     
+     sMins = Math.max(SHIFT_START_MINS, Math.min(sMins, SHIFT_END_MINS));
+     eMins = Math.max(SHIFT_START_MINS, Math.min(eMins, SHIFT_END_MINS));
+     
+     if (sMins >= eMins) return 0;
+     
+     var total = eMins - sMins;
+     var lunchOverlap = Math.max(0, Math.min(eMins, LUNCH_END_MINS) - Math.max(sMins, LUNCH_START_MINS));
+     return total - lunchOverlap;
+  }
+
+  var startStamp = sastDayStamp(start);
+  var endStamp = sastDayStamp(end);
+  var totalMinutes = 0;
+
+  if (startStamp === endStamp) {
+    var day = sastDayOfWeek(start);
+    if (day !== 0 && day !== 6) {
+      totalMinutes = getWorkingMins(start, end);
+    }
+  } else {
+    var startDow = sastDayOfWeek(start);
+    if (startDow !== 0 && startDow !== 6) {
+      totalMinutes += getWorkingMins(start, sastWallToDate(start, 15, 45));
+    }
+
+    var cursor = addSastDays(sastWallToDate(start, 12, 0), 1);
+    while (sastDayStamp(cursor) < endStamp) {
+      var dow = sastDayOfWeek(cursor);
+      if (dow !== 0 && dow !== 6) totalMinutes += SHIFT_DURATION;
+      cursor = addSastDays(cursor, 1);
+      if (totalMinutes > 200000) break;
+    }
+
+    var endDow = sastDayOfWeek(end);
+    if (endDow !== 0 && endDow !== 6) {
+      totalMinutes += getWorkingMins(sastWallToDate(end, 7, 30), end);
+    }
+  }
+
+  return totalMinutes;
+}
+
+function formatDurationServer(totalMins) {
+  var h = Math.floor(totalMins / 60);
+  var m = Math.floor(totalMins % 60);
+  return (h < 10 ? "0"+h : h) + ":" + (m < 10 ? "0"+m : m);
+}
+
+// --- ADMIN: FETCH ALL DATA ---
+function getAdminDashboardData() {
+  var ss = getSpreadsheet();
+  
+  // 1. Get Logs
+  var logSheet = getSheetOrDie(ss, TAB_LOGS);
+  var logData = logSheet.getDataRange().getValues();
+  logData.shift(); 
+  var logs = logData.map(function(row) {
+    var ts = row[6] ? new Date(row[6]) : (row[5] ? new Date(row[5]) : null);
+    if (ts && isNaN(ts.getTime())) ts = null; // Guard against Invalid Date
+    var weekStr = ts ? Utilities.formatDate(ts, "Africa/Johannesburg", "yyyy - 'Week' ww") : "Unknown Week";
+    
+    var startObj = row[5] ? new Date(row[5]) : null;
+    if (startObj && isNaN(startObj.getTime())) startObj = null;
+    var endObj = row[6] ? new Date(row[6]) : null;
+    if (endObj && isNaN(endObj.getTime())) endObj = null;
+    
+    return {
+      order: row[1],
+      worker: row[2],
+      role: row[3],
+      task: row[4],
+      start: startObj ? startObj.getTime() : null,
+      end: endObj ? endObj.getTime() : null,
+      qc: row[7],
+      pauseStart: (function() {
+        var meta = parseLogMeta(row.length > 12 ? row[12] : "");
+        var openStart = getOpenPauseStart(meta);
+        if (openStart) return new Date(openStart).getTime();
+        return row[9] ? new Date(row[9]).getTime() : null;
+      })(),
+      pausedMins: (function() {
+        var meta = parseLogMeta(row.length > 12 ? row[12] : "");
+        var closed = cumulativePauseMinsFromMeta(meta, row[4]);
+        if (closed) return closed;
+        return parseFloat(row[10]) || 0;
+      })(),
+      pauseIntervals: getPauseIntervalsForRow(row),
+      batchId: parseLogMeta(row.length > 12 ? row[12] : "").batchId || "",
+      batchShare: parseLogMeta(row.length > 12 ? row[12] : "").batchShare || 1,
+      batchSplitAt: parseLogMeta(row.length > 12 ? row[12] : "").batchSplitAt || null,
+      entryType: parseLogMeta(row.length > 12 ? row[12] : "").entryType || "production",
+      durationMins: calculateWorkMinutesFromLog(row),
+      week: weekStr
+    };
+  });
+
+  // 2. Get Orders (AND FILTER THEM)
+  var orderSheet = getSheetOrDie(ss, TAB_ORDERS);
+  var orderData = orderSheet.getDataRange().getValues();
+  orderData.shift(); 
+  
+  var orders = [];
+  
+  // Only include orders that are in the Allowed Workflow
+  for (var i = 0; i < orderData.length; i++) {
+    var status = orderData[i][2]; // Col C
+    
+    if (isAllowedStatus(status)) {
+       orders.push({ 
+         order: orderData[i][1], // Col B 
+         status: status 
+       });
+    }
+  }
+
+  return { logs: logs, orders: orders };
+}
+
+// --- UTILS ---
+function getNextStatus(current) {
+  var flow = [
+    "Not Yet Started", 
+    "Ready for Steelwork", "Profile Cutting", 
+    "Ready for Tagging", "Tagging", 
+    "Ready for Welding", "Welding", 
+    "Ready for Grinding", "Grinding", 
+    "Ready for Pre-Powder Coating", "Pre-Powder Coating",
+    "Ready for Powder Coating", // <--- ADDED THIS STEP
+    "Powder Coating", 
+    "Ready for Assembly", "Assembly", 
+    "Ready for Final QC", "Final QC",
+    "Ready for Delivery", "Out for Delivery", 
+    "Delivered"
+  ];
+  
+  // Case-insensitive search for current status
+  var currentTrimmed = String(current).trim();
+  var currentLower = currentTrimmed.toLowerCase();
+  var idx = -1;
+  
+  for (var i = 0; i < flow.length; i++) {
+    if (flow[i].toLowerCase() === currentLower) {
+      idx = i;
+      break;
+    }
+  }
+  
+  return (idx > -1 && idx < flow.length - 1) ? flow[idx + 1] : current; 
+}
+
+/**
+ * Scans the Production Log to find currently active MAIN FLOW workers.
+ * IT IGNORES PLATE CUTTING so parallel work can happen.
+ */
+function getActiveAssignments(ss) {
+  var logSheet = getSheetOrDie(ss, TAB_LOGS);
+  var logData = logSheet.getDataRange().getValues();
+  var assignments = {};
+
+  for (var i = 1; i < logData.length; i++) {
+    var orderNum = logData[i][1];
+    var worker = logData[i][2];
+    var role = logData[i][3];
+    var endTime = logData[i][6];
+    var meta = parseLogMeta(logData[i].length > 12 ? logData[i][12] : "");
+    if (meta.entryType === "indirect") continue;
+
+    var pauseStart = getOpenPauseStart(meta) || logData[i][9];
+    var pauseReason = "";
+    if (meta.pauses && meta.pauses.length) pauseReason = meta.pauses[meta.pauses.length - 1].reason || "";
+    if (!pauseReason) pauseReason = logData[i].length > 11 ? logData[i][11] : "";
+
+    var roleStr = String(role).trim();
+
+    if (!endTime && orderNum && roleStr !== 'Plate Cutting' && roleStr !== 'Out for Delivery' && roleStr !== 'Indirect') {
+      assignments[orderNum] = {
+        worker: worker,
+        isPaused: !!pauseStart,
+        pauseReason: pauseReason || "",
+        logId: logData[i][0],
+        batchId: meta.batchId || "",
+        isBatched: !!(meta.batchId && !meta.batchSplitAt && (meta.batchShare || 1) > 1)
+      };
+    }
+  }
+  return assignments;
+}
+
+function isAllowedStatus(status) {
+  if (!status) return false;
+  var s = String(status).trim().toLowerCase();
+  
+  var allowed = [
+    // Pre-Production
+    "not yet started", 
+    "ready for steelwork", "profile cutting", 
+    "ready for tagging", "tagging", 
+    "ready for welding", "welding", 
+    "ready for grinding", "grinding", 
+    // Powder Coating
+    "ready for pre-powder coating", "pre-powder coating",
+    "ready for powder coating", "powder coating", 
+    // Assembly & QC
+    "ready for assembly", "assembly", 
+    "ready for final qc", "final qc",
+    // Delivery
+    "ready for delivery", "out for delivery"
+    // Note: "delivered" and "completed" are NOT here, so they will be hidden.
+  ];
+  
+  return allowed.indexOf(s) > -1;
+}
+
+// --- METRICS DASHBOARD ---
+function getMetricsDashboardData() {
+  var ss = getSpreadsheet();
+  var logSheet = getSheetOrDie(ss, TAB_LOGS);
+  var usersSheet = getSheetOrDie(ss, TAB_USERS);
+  
+  // Get rates data
+  var ratesSheet = ss.getSheetByName(TAB_RATES);
+  var rates = {};
+  if (ratesSheet) {
+    var ratesData = ratesSheet.getDataRange().getValues();
+    // Skip header row
+    for (var i = 1; i < ratesData.length; i++) {
+      var role = String(ratesData[i][0]).trim();
+      var rate = parseFloat(ratesData[i][1]);
+      if (role && !isNaN(rate)) {
+        rates[role.toLowerCase()] = rate;
+      }
+    }
+  }
+  
+  // Get all logs
+  var logData = logSheet.getDataRange().getValues();
+  
+  // Get all workers from Users sheet
+  var usersData = usersSheet.getDataRange().getValues();
+  var workerRoles = {};
+  for (var i = 1; i < usersData.length; i++) {
+    var name = usersData[i][0];
+    var role = usersData[i][1];
+    if (name && role) {
+      workerRoles[name] = role;
+    }
+  }
+  
+  // Process logs to group by worker and order
+  var workerMetrics = {};
+  
+  for (var i = 1; i < logData.length; i++) {
+    var orderNum = logData[i][1];
+    var worker = logData[i][2];
+    var role = logData[i][3];
+    var task = logData[i][4];
+    var startTime = logData[i][5] ? new Date(logData[i][5]) : null;
+    var endTime = logData[i][6] ? new Date(logData[i][6]) : null;
+    
+    if (!worker || !orderNum) continue;
+    
+    // Initialize worker if not exists
+    if (!workerMetrics[worker]) {
+      workerMetrics[worker] = {
+        orders: {}
+      };
+    }
+    
+    // Initialize order if not exists
+    if (!workerMetrics[worker].orders[orderNum]) {
+      workerMetrics[worker].orders[orderNum] = {
+        totalMinutes: 0,
+        totalCost: 0,
+        tasks: []
+      };
+    }
+    
+    // Calculate duration
+    var durationMins = calculateWorkMinutesFromLog(logData[i]);
+    
+    // Get hourly rate for this role
+    var hourlyRate = rates[role.toLowerCase()] || 0;
+    var labourCost = (durationMins / 60) * hourlyRate;
+    
+    workerMetrics[worker].orders[orderNum].totalMinutes += durationMins;
+    workerMetrics[worker].orders[orderNum].totalCost += labourCost;
+    workerMetrics[worker].orders[orderNum].tasks.push({
+      task: task,
+      role: role,
+      startTime: startTime ? startTime.getTime() : null,
+      endTime: endTime ? endTime.getTime() : null,
+      durationMins: durationMins,
+      labourCost: labourCost
+    });
+  }
+  
+  // Format the data for the frontend
+  var result = [];
+  for (var worker in workerMetrics) {
+    var orders = workerMetrics[worker].orders;
+    var orderList = [];
+    
+    for (var orderNum in orders) {
+      var orderData = orders[orderNum];
+      orderList.push({
+        order: orderNum,
+        totalMinutes: orderData.totalMinutes,
+        totalCost: orderData.totalCost,
+        tasks: orderData.tasks
+      });
+    }
+    
+    // Sort by most recent (based on latest task end time or start time)
+    orderList.sort(function(a, b) {
+      var aTime = 0;
+      var bTime = 0;
+      
+      for (var i = 0; i < a.tasks.length; i++) {
+        var t = a.tasks[i].endTime || a.tasks[i].startTime || 0;
+        if (t > aTime) aTime = t;
+      }
+      
+      for (var i = 0; i < b.tasks.length; i++) {
+        var t = b.tasks[i].endTime || b.tasks[i].startTime || 0;
+        if (t > bTime) bTime = t;
+      }
+      
+      return bTime - aTime; // Most recent first
+    });
+    
+    // Take only last 5 orders
+    var last5Orders = orderList.slice(0, 5);
+    
+    // Calculate highest cost from the last 5 orders only
+    var maxCost = 0;
+    var maxCostOrder = '';
+    for (var i = 0; i < last5Orders.length; i++) {
+      if (last5Orders[i].totalCost > maxCost) {
+        maxCost = last5Orders[i].totalCost;
+        maxCostOrder = last5Orders[i].order;
+      }
+    }
+    
+    result.push({
+      worker: worker,
+      role: workerRoles[worker] || 'Unknown',
+      orders: last5Orders,
+      highestCostOrder: maxCostOrder,
+      highestCost: maxCost
+    });
+  }
+  
+  return result;
+}
+
+/**
+ * Sort processes by manufacturing workflow order
+ * Returns a sorted array of process names
+ */
+function sortProcessesByWorkflow(processes) {
+  // Define the manufacturing workflow order
+  var workflowOrder = [
+    'Profile Cutting',
+    'Plate Cutting',
+    'Tagging',
+    'Welding',
+    'Grinding',
+    'Powder Coating',
+    'Assembly'
+  ];
+  
+  // Create a map for quick lookup of order position
+  var orderMap = {};
+  for (var i = 0; i < workflowOrder.length; i++) {
+    orderMap[workflowOrder[i].toLowerCase()] = i;
+  }
+  
+  // Sort processes using the workflow order (create a copy to avoid mutation)
+  return processes.slice().sort(function(a, b) {
+    var indexA = orderMap[a.toLowerCase()];
+    var indexB = orderMap[b.toLowerCase()];
+    
+    // If both are in the workflow order, sort by their position
+    if (indexA !== undefined && indexB !== undefined) {
+      return indexA - indexB;
+    }
+    
+    // If only A is in the workflow, it comes first
+    if (indexA !== undefined) return -1;
+    
+    // If only B is in the workflow, it comes first
+    if (indexB !== undefined) return 1;
+    
+    // If neither is in the workflow, sort alphabetically
+    return a.localeCompare(b);
+  });
+}
+
+/**
+ * Get order-based metrics with production processes as columns
+ * Returns: { processes: [], orders: [{orderNum, productName, processes: {processName: {totalMinutes, totalCost}}}] }
+ * Note: Uses calculateWorkMinutesServer() function defined in this file
+ */
+function getOrderMetrics() {
+  var ss = getSpreadsheet();
+  var logSheet = getSheetOrDie(ss, TAB_LOGS);
+  var ordersSheet = getSheetOrDie(ss, TAB_ORDERS);
+  var ratesSheet = ss.getSheetByName(TAB_RATES);
+  
+  // Get rates data
+  var rates = {};
+  if (ratesSheet) {
+    var ratesData = ratesSheet.getDataRange().getValues();
+    for (var i = 1; i < ratesData.length; i++) {
+      var role = String(ratesData[i][0]).trim();
+      var rate = parseFloat(ratesData[i][1]);
+      if (role && !isNaN(rate)) {
+        rates[role.toLowerCase()] = rate;
+      }
+    }
+  }
+  
+  // Get product names
+  var ordersData = ordersSheet.getDataRange().getValues();
+  var orderProducts = {};
+  for (var i = 1; i < ordersData.length; i++) {
+    var orderNum = ordersData[i][1]; 
+    var productName = ordersData[i][6]; 
+    if (orderNum && productName) {
+      orderProducts[String(orderNum).trim()] = String(productName).trim();
+    }
+  }
+  
+  var logData = logSheet.getDataRange().getValues();
+  var processesSet = {};
+  var weeksSet = {};
+  var orderMetrics = {};
+  
+  // Process logs - group by order, process, AND week
+  for (var i = 1; i < logData.length; i++) {
+    var orderNum = logData[i][1];
+    var worker = logData[i][2];
+    var role = logData[i][3];
+    var task = logData[i][4];
+    var startTime = logData[i][5] ? new Date(logData[i][5]) : null;
+    if (startTime && isNaN(startTime.getTime())) startTime = null;
+    var endTime = logData[i][6] ? new Date(logData[i][6]) : null;
+    if (endTime && isNaN(endTime.getTime())) endTime = null;
+    
+    if (!orderNum || !task) continue;
+    
+    var processName = String(task).trim();
+    if (processName.toLowerCase() === 'pre-powder coating' || processName.toLowerCase() === 'final qc') continue;
+    
+    processesSet[processName] = true;
+    
+    // Determine the exact week this specific log entry ended
+    var ts = endTime ? endTime.getTime() : (startTime ? startTime.getTime() : 0);
+    if (isNaN(ts)) ts = 0; // Guard against Invalid Date
+    var weekStr = ts ? Utilities.formatDate(new Date(ts), "Africa/Johannesburg", "yyyy - 'Week' ww") : "Unknown Week";
+    weeksSet[weekStr] = true;
+    
+    if (!orderMetrics[orderNum]) {
+      orderMetrics[orderNum] = {
+        orderNum: orderNum,
+        productName: orderProducts[String(orderNum).trim()] || 'Unknown',
+        processes: {}
+      };
+    }
+    
+    if (!orderMetrics[orderNum].processes[processName]) {
+      orderMetrics[orderNum].processes[processName] = {
+        totalMinutes: 0,
+        totalCost: 0,
+        workers:[],
+        weeklyData: {}
+      };
+    }
+    
+    if (!orderMetrics[orderNum].processes[processName].weeklyData[weekStr]) {
+      orderMetrics[orderNum].processes[processName].weeklyData[weekStr] = {
+        minutes: 0,
+        cost: 0,
+        workers:[]
+      };
+    }
+    
+    var durationMins = calculateWorkMinutesFromLog(logData[i]);
+    var hourlyRate = rates[role.toLowerCase()] || 0;
+    var labourCost = (durationMins / 60) * hourlyRate;
+    
+    // Add to absolute totals
+    orderMetrics[orderNum].processes[processName].totalMinutes += durationMins;
+    orderMetrics[orderNum].processes[processName].totalCost += labourCost;
+    
+    // Add to specific week totals
+    orderMetrics[orderNum].processes[processName].weeklyData[weekStr].minutes += durationMins;
+    orderMetrics[orderNum].processes[processName].weeklyData[weekStr].cost += labourCost;
+    
+    if (worker) {
+      if (orderMetrics[orderNum].processes[processName].workers.indexOf(worker) === -1) {
+        orderMetrics[orderNum].processes[processName].workers.push(worker);
+      }
+      if (orderMetrics[orderNum].processes[processName].weeklyData[weekStr].workers.indexOf(worker) === -1) {
+        orderMetrics[orderNum].processes[processName].weeklyData[weekStr].workers.push(worker);
+      }
+    }
+  }
+  
+  var processes = sortProcessesByWorkflow(Object.keys(processesSet));
+  var weeks = Object.keys(weeksSet).sort().reverse();
+  var orders =[];
+  for (var orderKey in orderMetrics) {
+    orders.push(orderMetrics[orderKey]);
+  }
+  
+  return { processes: processes, weeks: weeks, orders: orders };
+}
+
+/**
+ * Get production trends data for line graph
+ * Returns: { processes: [], products: [], orderData: [{orderNum, productName, processes: {}}] }
+ * Note: Uses calculateWorkMinutesServer() function defined in this file
+ */
+function getProductionTrendsData() {
+  // It uses the exact same core logic as getOrderMetrics now, but adds the products list
+  var data = getOrderMetrics(); 
+  
+  var productsSet = {};
+  for (var i = 0; i < data.orders.length; i++) {
+     productsSet[data.orders[i].productName] = true;
+  }
+  
+  return {
+    processes: data.processes,
+    products: Object.keys(productsSet).sort(),
+    weeks: data.weeks,
+    orderData: data.orders
+  };
+}
+
+function reportScratchedGlass(orderNum, workerName) {
+  try {
+    var emailBody = "<p><strong>URGENT: Scratched Glass Reported</strong></p>" +
+                    "<p>Order Number: <strong>" + orderNum + "</strong></p>" +
+                    "<p>Reported By: <strong>" + workerName + "</strong></p>" +
+                    "<p>Task: Assembly</p>" +
+                    "<p>The worker has been blocked from starting the assembly for this order because the glass is scratched.</p>";
+
+    var recipient = (typeof ALERT_EMAIL_RECIPIENT !== 'undefined' && ALERT_EMAIL_RECIPIENT) 
+                      ? ALERT_EMAIL_RECIPIENT 
+                      : "siyabonga.msiza@studiodelta.co.za,shaka.chabalala@deltabec.com";
+
+    MailApp.sendEmail({
+      to: recipient,
+      subject: "⚠️ Scratched Glass Alert - Order " + orderNum,
+      htmlBody: emailBody
+    });
+
+    return { success: true };
+  } catch(e) {
+    throw new Error("Failed to send email: " + e.toString());
+  }
+}
+
+function generatePowderCoatingList(listData, workerName) {
+  try {
+    var dateStr = new Date().toLocaleDateString();
+    var timeStr = new Date().toLocaleTimeString();
+    var fileName = "Powder_Coating_List_" + new Date().toISOString().slice(0,10);
+    
+    // Build HTML for the PDF Document
+    var html = "<html><head><style>" +
+               "body { font-family: Arial, sans-serif; margin: 20px; color: #333; }" +
+               "h2 { text-align: center; margin-bottom: 5px; text-transform: uppercase; }" +
+               "p { text-align: center; margin-top: 0; font-size: 14px; color: #555; }" +
+               "table { width: 100%; border-collapse: collapse; margin-top: 30px; font-size: 11px; }" +
+               "th, td { border: 1px solid #999; padding: 10px 8px; text-align: center; vertical-align: middle; }" +
+               "th { background-color: #f2f2f2; font-weight: bold; text-transform: uppercase; font-size: 10px; }" +
+               ".desc { text-align: left; }" +
+               "</style></head><body>" +
+               "<h2>Studio Delta - Powder Coating List</h2>" +
+               "<p>Generated By: <strong>" + workerName + "</strong> on " + dateStr + " at " + timeStr + "</p>" +
+               "<table>" +
+               "<thead><tr>" +
+               "<th style='width: 12%'>Order #</th>" +
+               "<th style='width: 25%'>Item Description</th>" +
+               "<th style='width: 15%'>Dimensions<br>(H x W x D)</th>" +
+               "<th style='width: 8%'>QTY</th>" +
+               "<th style='width: 15%'>Colour</th>" +
+               "<th style='width: 25%'>Profiles Used</th>" +
+               "</tr></thead><tbody>";
+               
+    // Loop through selected orders and add rows
+    for (var i = 0; i < listData.length; i++) {
+      var item = listData[i];
+      html += "<tr>" +
+              "<td><strong>" + item.order + "</strong></td>" +
+              "<td class='desc'>" + item.desc + "</td>" +
+              "<td>" + item.dimensions + "</td>" +
+              "<td>" + item.qty + "</td>" +
+              "<td>" + item.color + "</td>" +
+              "<td class='desc'>" + item.profiles + "</td>" +
+              "</tr>";
+    }
+    
+    html += "</tbody></table></body></html>";
+    
+    // Convert the HTML to a PDF Blob
+    var blob = HtmlService.createHtmlOutput(html).getAs('application/pdf').setName(fileName + ".pdf");
+    
+    // Check if folder exists, if not create it
+    var folders = DriveApp.getFoldersByName(POWDER_FOLDER_NAME);
+    var folder = folders.hasNext() ? folders.next() : DriveApp.createFolder(POWDER_FOLDER_NAME);
+    
+    // Save to Drive
+    var file = folder.createFile(blob);
+    var fileUrl = file.getUrl();
+    
+    // Send Email if an address is provided in settings
+    if (POWDER_EMAIL_RECIPIENT && POWDER_EMAIL_RECIPIENT.trim() !== "") {
+      MailApp.sendEmail({
+        to: POWDER_EMAIL_RECIPIENT,
+        subject: "Studio Delta - Powder Coating List (" + dateStr + ")",
+        htmlBody: "<p>Good day,</p><p>Please find attached the latest Powder Coating List generated by " + workerName + " on " + dateStr + ".</p><p>Regards,<br>Studio Delta</p>",
+        attachments: [blob]
+      });
+    }
+    
+    return { success: true, url: fileUrl };
+  } catch (e) {
+    return { success: false, error: e.toString() };
+  }
+}
+
+function batchStartOrders(rowIndices, workerName, role) {
+  try {
+    return startOrder(rowIndices[0], workerName, role, rowIndices);
+  } catch(e) {
+    Logger.log("Batch start error: " + e);
+    return {success: false, error: e.toString()};
+  }
+}
+
+function batchFinishOrders(rowIndices, workerName) {
+  for(var i = 0; i < rowIndices.length; i++) {
+    try {
+      // By passing null for qcData, it bypasses checklists (allowed for Powder/Delivery)
+      finishOrder(rowIndices[i], null, null, null, null, workerName);
+    } catch(e) {
+      Logger.log("Batch finish error for row " + rowIndices[i] + ": " + e);
+    }
+  }
+  return {success: true};
+}
+
+// --- WORKER PAUSE / RESUME FEATURES ---
+function workerPauseOrder(rowIndex, orderNum, workerName, reason) {
+  var lock = LockService.getScriptLock();
+  lock.waitLock(10000);
+  try {
+    var ss = getSpreadsheet();
+    var logSheet = getSheetOrDie(ss, TAB_LOGS);
+    var logs = logSheet.getDataRange().getValues();
+    var pausedSomething = false;
+    for (var i = logs.length - 1; i >= 1; i--) {
+      if (String(logs[i][1]) === String(orderNum) && String(logs[i][2]).trim() === String(workerName).trim() && !logs[i][6]) {
+         var meta = parseLogMeta(logs[i].length > 12 ? logs[i][12] : "");
+         if (!hasOpenPause(meta.pauses) && !logs[i][9]) {
+            meta = addPauseToMeta(meta, reason);
+            writeLogMeta(logSheet, i + 1, meta);
+            syncLegacyPauseCells(logSheet, i + 1, meta, logs[i][4]);
+            pausedSomething = true;
+         }
+      }
+    }
+    if (!pausedSomething) return {success: false, message: "No active tasks running for you on this order."};
+    return {success: true};
+  } catch(e) {
+    return {success: false, message: e.toString()};
+  } finally {
+    lock.releaseLock();
+  }
+}
+
+function workerResumeOrder(rowIndex, orderNum, workerName) {
+  var lock = LockService.getScriptLock();
+  lock.waitLock(10000);
+  try {
+    var ss = getSpreadsheet();
+    autoPauseWorkerOtherJobs(ss, workerName, [orderNum], "Switched to order " + orderNum, "");
+    closeIndirectTasksForWorker(ss, workerName);
+    var ok = resumeWorkerLog(ss, workerName, orderNum);
+    if (!ok) return {success: false, message: "No paused tasks found for you on this order."};
+    return {success: true};
+  } catch(e) {
+    return {success: false, message: e.toString()};
+  } finally {
+    lock.releaseLock();
+  }
+}
+
+function adminPauseOrder(orderNum) {
+  var lock = LockService.getScriptLock();
+  lock.waitLock(10000);
+  try {
+    var ss = getSpreadsheet();
+    var logSheet = getSheetOrDie(ss, TAB_LOGS);
+    var logs = logSheet.getDataRange().getValues();
+    var pausedSomething = false;
+    for (var i = logs.length - 1; i >= 1; i--) {
+      if (String(logs[i][1]) === String(orderNum) && !logs[i][6]) {
+         var meta = parseLogMeta(logs[i].length > 12 ? logs[i][12] : "");
+         if (!hasOpenPause(meta.pauses) && !logs[i][9]) {
+            meta = addPauseToMeta(meta, "Admin pause");
+            writeLogMeta(logSheet, i + 1, meta);
+            syncLegacyPauseCells(logSheet, i + 1, meta, logs[i][4]);
+            pausedSomething = true;
+         }
+      }
+    }
+    if (!pausedSomething) return {success: false, message: "No active tasks running for this order."};
+    return {success: true};
+  } catch(e) {
+    return {success: false, message: e.toString()};
+  } finally {
+    lock.releaseLock();
+  }
+}
+
+function adminResumeOrder(orderNum) {
+  var lock = LockService.getScriptLock();
+  lock.waitLock(10000);
+  try {
+    var ss = getSpreadsheet();
+    var logSheet = getSheetOrDie(ss, TAB_LOGS);
+    var logs = logSheet.getDataRange().getValues();
+    var resumedSomething = false;
+    for (var i = logs.length - 1; i >= 1; i--) {
+      if (String(logs[i][1]) === String(orderNum) && !logs[i][6]) {
+         var meta = parseLogMeta(logs[i].length > 12 ? logs[i][12] : "");
+         if (hasOpenPause(meta.pauses) || logs[i][9]) {
+            meta = closeOpenPauseInMeta(meta, new Date());
+            writeLogMeta(logSheet, i + 1, meta);
+            syncLegacyPauseCells(logSheet, i + 1, meta, logs[i][4]);
+            resumedSomething = true;
+         }
+      }
+    }
+    if (!resumedSomething) return {success: false, message: "No paused tasks found."};
+    return {success: true};
+  } catch(e) {
+    return {success: false, message: e.toString()};
+  } finally {
+    lock.releaseLock();
+  }
+}
+
+function processPdfQueue() {
+  var lock = LockService.getScriptLock();
+  if (!lock.tryLock(10000)) return; // Exit if another trigger is already running
+  
+  try {
+    var queueFolder = DriveApp.getFolderById(QUEUE_FOLDER_ID);
+    var files = queueFolder.getFilesByType(MimeType.PLAIN_TEXT);
+    
+    // If no files are waiting, release lock and exit
+    if (!files.hasNext()) return; 
+    
+    var file = files.next();
+    var fileContent = file.getBlob().getDataAsString();
+    var jobData = JSON.parse(fileContent);
+    
+    var ss = getSpreadsheet();
+    var logSheet = getSheetOrDie(ss, TAB_LOGS);
+    
+    // --- GENERATE THE PDF ---
+    var templateId = TEMP_ID_PRE_POWDER;
+    if (jobData.processName === 'Final QC') {
+        templateId = TEMP_ID_FINISHED;
+    }
+    
+    // Pass the data to the PDF generator
+    var pdfUrl = generateQCPdf(
+      templateId, 
+      jobData.orderNum, 
+      jobData.workerName, 
+      jobData.qcData, 
+      jobData.signatureUrl, 
+      jobData.filesData, 
+      true
+    );
+    
+    // --- UPDATE THE LOG SHEET ---
+    if (pdfUrl) {
+      var currentResult = logSheet.getRange(jobData.rowToUpdate, 8).getValue();
+      logSheet.getRange(jobData.rowToUpdate, 8).setValue(currentResult + "\n\nQC PDF: " + pdfUrl);
+    }
+    
+    // --- CLEAN UP ---
+    // Delete the job file from the queue folder now that it is complete
+    file.setTrashed(true); 
+    
+  } catch (err) {
+    Logger.log("Queue Processing Error: " + err.toString());
+    // Rename the file to ERROR_ so it gets skipped next time but isn't lost
+    if (file) {
+      file.setName("ERROR_" + file.getName());
+    }
+  } finally {
+    lock.releaseLock();
+  }
+}
+
+// --- WEEKLY COMPLETIONS ANALYTICS ---
+function getWeeklyAnalyticsData() {
+  var ss = getSpreadsheet();
+  var logSheet = getSheetOrDie(ss, TAB_LOGS);
+  var ordersSheet = getSheetOrDie(ss, TAB_ORDERS);
+  
+  // Get product names to map to orders
+  var ordersData = ordersSheet.getDataRange().getValues();
+  var orderProducts = {};
+  for (var i = 1; i < ordersData.length; i++) {
+    var orderNum = String(ordersData[i][1]).trim();
+    var productName = String(ordersData[i][6]).trim(); // Column G is Product Name
+    if (orderNum && productName) {
+      orderProducts[orderNum] = productName;
+    }
+  }
+  
+  var logData = logSheet.getDataRange().getValues();
+  
+  var weeklyData = {}; 
+  var processesSet = {};
+
+  // FIRST PASS: Aggregate completion dates and worker assignments per process per order
+  var processAggregates = {};
+  // Start from 1 to skip header
+  for (var i = 1; i < logData.length; i++) {
+    var orderNum = String(logData[i][1]).trim();
+    var worker = String(logData[i][2]).trim();
+    var task = String(logData[i][4]).trim();
+    var endTime = logData[i][6]; // Column G (End Time)
+    
+    // Only count tasks that actually have an End Time (Completed)
+    if (!orderNum || !task || !endTime) continue; 
+    
+    // Exclude QC tasks from manufacturing throughput (Optional, keeps the board clean)
+    var lowerTask = task.toLowerCase();
+    if (lowerTask === 'pre-powder coating' || lowerTask === 'final qc') {
+       continue; 
+    }
+
+    var aggKey = orderNum + "|" + task;
+    var ts = new Date(endTime).getTime();
+    if (isNaN(ts)) ts = 0;
+    
+    if (!processAggregates[aggKey]) {
+      processAggregates[aggKey] = {
+        orderNum: orderNum,
+        processName: task,
+        maxEndTime: ts,
+        workers: worker ? [worker] : []
+      };
+    } else {
+      if (ts > processAggregates[aggKey].maxEndTime) {
+        processAggregates[aggKey].maxEndTime = ts;
+      }
+      if (worker && processAggregates[aggKey].workers.indexOf(worker) === -1) {
+        processAggregates[aggKey].workers.push(worker);
+      }
+    }
+  }
+
+  // SECOND PASS: Group aggregated processes by their specific phase completion week
+  for (var key in processAggregates) {
+    var agg = processAggregates[key];
+    var processName = agg.processName;
+    processesSet[processName] = true;
+    
+    // Format the date into "YYYY - Week WW" using the PHASE'S final end time
+    var weekStr = "Unknown Week";
+    if (agg.maxEndTime && !isNaN(agg.maxEndTime)) {
+      weekStr = Utilities.formatDate(new Date(agg.maxEndTime), "Africa/Johannesburg", "yyyy - 'Week' ww");
+    }
+    
+    if (!weeklyData[weekStr]) weeklyData[weekStr] = {};
+    if (!weeklyData[weekStr][processName]) weeklyData[weekStr][processName] = [];
+    
+    // Push the compiled details for the pop-up modal
+    weeklyData[weekStr][processName].push({
+       orderNum: agg.orderNum,
+       productName: orderProducts[agg.orderNum] || 'Unknown Product',
+       worker: agg.workers.length > 0 ? agg.workers.join(", ") : "Unknown"
+    });
+  }
+  
+  // Use existing helper to sort processes properly (Welding -> Grinding -> Powder)
+  var processes = sortProcessesByWorkflow(Object.keys(processesSet));
+  
+  // Sort weeks descending (newest weeks at the top)
+  var weeks = Object.keys(weeklyData).sort().reverse(); 
+  
+  return {
+    weeks: weeks,
+    processes: processes,
+    data: weeklyData
+  };
+}
+
+function getQCReportsFast() {
+  var folderId = "1pyzJ-jcgltJlrCOwjR7c8AIFxwcd2YcK"; // Your exact QC Folder ID
+  var list = [];
+  
+  try {
+    var folder = DriveApp.getFolderById(folderId);
+    
+    // 1. Instantly unlock the folder for Admins (ignores errors if you aren't the owner)
+    try {
+      folder.setSharing(DriveApp.Access.ANYONE_WITH_LINK, DriveApp.Permission.VIEW);
+    } catch(e) {}
+    
+    // 2. Get EVERY file directly from this specific folder
+    var files = folder.getFiles();
+    
+    while (files.hasNext()) {
+      var file = files.next();
+      var name = file.getName();
+      
+      // Ensure we only grab PDFs (checking both name and file type to be safe)
+      if (name.toLowerCase().indexOf('.pdf') > -1 || file.getMimeType() === MimeType.PDF) {
+        list.push({
+          name: name.replace('.pdf', ''),
+          url: file.getUrl(),
+          dateCreated: file.getDateCreated().getTime()
+        });
+      }
+    }
+  } catch(e) {
+    throw new Error("Could not read folder. Error: " + e.toString());
+  }
+  
+  // 3. Sort by newest first
+  list.sort(function(a, b) { return b.dateCreated - a.dateCreated; });
+  
+  // Return the most recent 300 so the app stays fast
+  return list.slice(0, 300);
+}
+
+// =============================================================================
+// TIME ENGINE (Johannesburg) — one running clock, pause intervals, batch split
+// =============================================================================
+
+function defaultLogMeta() {
+  return {
+    pauses: [],
+    batchId: "",
+    batchShare: 1,
+    batchSplitAt: null,
+    entryType: "production"
+  };
+}
+
+function parseLogMeta(cell) {
+  var meta = defaultLogMeta();
+  if (cell === null || cell === undefined || cell === "") return meta;
+  var s = String(cell).trim();
+  if (!s) return meta;
+  try {
+    var parsed = JSON.parse(s);
+    if (!parsed || typeof parsed !== "object") return meta;
+    meta.pauses = parsed.pauses || [];
+    meta.batchId = parsed.batchId || "";
+    meta.batchShare = parsed.batchShare || 1;
+    meta.batchSplitAt = parsed.batchSplitAt || null;
+    meta.entryType = parsed.entryType || "production";
+    return meta;
+  } catch (e) {
+    return meta;
+  }
+}
+
+function writeLogMeta(logSheet, rowNum, meta) {
+  logSheet.getRange(rowNum, 13).setValue(JSON.stringify(meta));
+}
+
+function asSast(date) {
+  return new Date(date.getTime() + SAST_OFFSET_MS);
+}
+
+function sastDayOfWeek(date) {
+  return asSast(date).getUTCDay();
+}
+
+function sastMinsOfDay(date) {
+  var d = asSast(date);
+  return d.getUTCHours() * 60 + d.getUTCMinutes() + d.getUTCSeconds() / 60;
+}
+
+function sastDayStamp(date) {
+  return Utilities.formatDate(date, TZ_JOBURG, "yyyy-MM-dd");
+}
+
+function sastWallToDate(date, hours, minutes) {
+  var d = asSast(date);
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate(), hours - 2, minutes, 0, 0));
+}
+
+function addSastDays(date, days) {
+  return new Date(date.getTime() + days * 86400000);
+}
+
+function isWithinShiftNow() {
+  var now = new Date();
+  var dow = sastDayOfWeek(now);
+  if (dow === 0 || dow === 6) return false;
+  var mins = sastMinsOfDay(now);
+  return mins >= (7 * 60 + 30) && mins <= (15 * 60 + 45);
+}
+
+function getPauseIntervalsForRow(row) {
+  var meta = parseLogMeta(row.length > 12 ? row[12] : "");
+  var pauses = meta.pauses ? meta.pauses.slice() : [];
+  if (pauses.length === 0 && row[9]) {
+    pauses.push({
+      start: new Date(row[9]).getTime(),
+      end: row[6] ? new Date(row[6]).getTime() : null,
+      reason: row.length > 11 ? String(row[11] || "") : ""
+    });
+  }
+  return pauses;
+}
+
+function sumPauseMinutesInWindow(pauses, wStart, wEnd, taskName) {
+  if (!pauses || !wStart || !wEnd) return 0;
+  var total = 0;
+  var w0 = wStart.getTime();
+  var w1 = wEnd.getTime();
+  for (var i = 0; i < pauses.length; i++) {
+    var ps = new Date(pauses[i].start).getTime();
+    var pe = pauses[i].end ? new Date(pauses[i].end).getTime() : w1;
+    var a = Math.max(ps, w0);
+    var b = Math.min(pe, w1);
+    if (b > a) total += calcRawServerMins(new Date(a), new Date(b), taskName);
+  }
+  return total;
+}
+
+function calculateWorkMinutesMeta(start, end, taskName, meta, legacyPausedMins) {
+  if (!start) return 0;
+  var actualEnd = end ? end : new Date();
+  meta = meta || defaultLogMeta();
+  var pauses = meta.pauses || [];
+  var share = Math.max(1, parseFloat(meta.batchShare) || 1);
+  var splitAt = meta.batchSplitAt ? new Date(meta.batchSplitAt) : null;
+
+  if (pauses.length === 0 && legacyPausedMins && !meta.batchId) {
+    var rawLegacy = calcRawServerMins(start, actualEnd, taskName);
+    return Math.max(0, rawLegacy - (parseFloat(legacyPausedMins) || 0));
+  }
+
+  if (splitAt && splitAt.getTime() > start.getTime() && splitAt.getTime() < actualEnd.getTime()) {
+    var beforeRaw = calcRawServerMins(start, splitAt, taskName);
+    var afterRaw = calcRawServerMins(splitAt, actualEnd, taskName);
+    var beforePause = sumPauseMinutesInWindow(pauses, start, splitAt, taskName);
+    var afterPause = sumPauseMinutesInWindow(pauses, splitAt, actualEnd, taskName);
+    return Math.max(0, beforeRaw - beforePause) / share + Math.max(0, afterRaw - afterPause);
+  }
+
+  var raw = calcRawServerMins(start, actualEnd, taskName);
+  var pauseMins = sumPauseMinutesInWindow(pauses, start, actualEnd, taskName);
+  var net = Math.max(0, raw - pauseMins);
+  if (!splitAt && share > 1 && meta.batchId) return net / share;
+  return net;
+}
+
+function calculateWorkMinutesFromLog(row) {
+  var start = row[5] ? new Date(row[5]) : null;
+  if (start && isNaN(start.getTime())) start = null;
+  var end = row[6] ? new Date(row[6]) : null;
+  if (end && isNaN(end.getTime())) end = null;
+  var task = row[4];
+  var meta = parseLogMeta(row.length > 12 ? row[12] : "");
+  if (row[9] && !hasOpenPause(meta.pauses)) {
+    meta.pauses = getPauseIntervalsForRow(row);
+  }
+  return calculateWorkMinutesMeta(start, end, task, meta, row[10]);
+}
+
+function hasOpenPause(pauses) {
+  if (!pauses) return false;
+  for (var i = 0; i < pauses.length; i++) {
+    if (!pauses[i].end) return true;
+  }
+  return false;
+}
+
+function getOpenPauseStart(meta) {
+  var pauses = (meta && meta.pauses) || [];
+  for (var i = pauses.length - 1; i >= 0; i--) {
+    if (!pauses[i].end) return pauses[i].start;
+  }
+  return null;
+}
+
+function addPauseToMeta(meta, reason) {
+  meta = meta || defaultLogMeta();
+  if (hasOpenPause(meta.pauses)) return meta;
+  meta.pauses.push({
+    start: new Date().getTime(),
+    end: null,
+    reason: reason || ""
+  });
+  return meta;
+}
+
+function closeOpenPauseInMeta(meta, atTime) {
+  meta = meta || defaultLogMeta();
+  var endMs = (atTime ? new Date(atTime) : new Date()).getTime();
+  for (var i = meta.pauses.length - 1; i >= 0; i--) {
+    if (!meta.pauses[i].end) {
+      meta.pauses[i].end = endMs;
+      break;
+    }
+  }
+  return meta;
+}
+
+function cumulativePauseMinsFromMeta(meta, taskName) {
+  var pauses = (meta && meta.pauses) || [];
+  var total = 0;
+  var now = new Date();
+  for (var i = 0; i < pauses.length; i++) {
+    if (!pauses[i].end) continue;
+    total += calcRawServerMins(new Date(pauses[i].start), new Date(pauses[i].end), taskName);
+  }
+  return total;
+}
+
+function syncLegacyPauseCells(logSheet, rowNum, meta, taskName) {
+  var openStart = getOpenPauseStart(meta);
+  var lastReason = "";
+  if (meta.pauses && meta.pauses.length) {
+    lastReason = meta.pauses[meta.pauses.length - 1].reason || "";
+  }
+  if (openStart) {
+    logSheet.getRange(rowNum, 10).setValue(new Date(openStart));
+    logSheet.getRange(rowNum, 12).setValue(lastReason);
+  } else {
+    logSheet.getRange(rowNum, 10).clearContent();
+    logSheet.getRange(rowNum, 12).clearContent();
+  }
+  logSheet.getRange(rowNum, 11).setValue(cumulativePauseMinsFromMeta(meta, taskName));
+}
+
+function findOrderRowByNumber(orderSheet, orderNum) {
+  var last = orderSheet.getLastRow();
+  if (last < 2) return -1;
+  var col = orderSheet.getRange(2, 2, last - 1, 1).getValues();
+  for (var i = 0; i < col.length; i++) {
+    if (String(col[i][0]) === String(orderNum)) return i + 2;
+  }
+  return -1;
+}
+
+function findOpenLogRow(logs, logId, orderNum, workerName) {
+  var rowToUpdate = -1;
+  if (logId) {
+    var normalizedLogId = String(logId).trim();
+    for (var i = 1; i < logs.length; i++) {
+      if (String(logs[i][0]).trim() === normalizedLogId) {
+        rowToUpdate = i + 1;
+        break;
+      }
+    }
+  }
+  if (rowToUpdate !== -1) {
+    var r = logs[rowToUpdate - 1];
+    var matchesOrder = !orderNum || String(r[1]) === String(orderNum);
+    var matchesWorker = !workerName || String(r[2]).trim() === String(workerName).trim();
+    var isOpen = !r[6];
+    if (!matchesOrder || !matchesWorker || !isOpen) rowToUpdate = -1;
+  }
+  if (rowToUpdate === -1 && orderNum && workerName) {
+    for (var j = logs.length - 1; j >= 1; j--) {
+      if (String(logs[j][1]) === String(orderNum) &&
+          String(logs[j][2]).trim() === String(workerName).trim() &&
+          !logs[j][6]) {
+        rowToUpdate = j + 1;
+        break;
+      }
+    }
+  }
+  return rowToUpdate;
+}
+
+function closeIndirectTasksForWorker(ss, workerName) {
+  var logSheet = getSheetOrDie(ss, TAB_LOGS);
+  var logs = logSheet.getDataRange().getValues();
+  var closed = 0;
+  var now = new Date();
+  for (var i = 1; i < logs.length; i++) {
+    var meta = parseLogMeta(logs[i].length > 12 ? logs[i][12] : "");
+    var isIndirect = meta.entryType === "indirect" || String(logs[i][3]).trim() === "Indirect";
+    if (isIndirect && String(logs[i][2]).trim() === String(workerName).trim() && !logs[i][6]) {
+      meta = closeOpenPauseInMeta(meta, now);
+      logSheet.getRange(i + 1, 7).setValue(now);
+      writeLogMeta(logSheet, i + 1, meta);
+      syncLegacyPauseCells(logSheet, i + 1, meta, logs[i][4]);
+      closed++;
+    }
+  }
+  return closed;
+}
+
+function autoPauseWorkerOtherJobs(ss, workerName, exceptOrders, reason, exceptBatchId) {
+  var logSheet = getSheetOrDie(ss, TAB_LOGS);
+  var logs = logSheet.getDataRange().getValues();
+  var exceptMap = {};
+  (exceptOrders || []).forEach(function(o) { exceptMap[String(o)] = true; });
+  var paused = [];
+  for (var i = 1; i < logs.length; i++) {
+    var meta = parseLogMeta(logs[i].length > 12 ? logs[i][12] : "");
+    if (meta.entryType === "indirect") continue;
+    if (logs[i][6]) continue;
+    if (String(logs[i][2]).trim() !== String(workerName).trim()) continue;
+    if (exceptMap[String(logs[i][1])]) continue;
+    if (exceptBatchId && meta.batchId && meta.batchId === exceptBatchId) continue;
+    if (hasOpenPause(meta.pauses) || logs[i][9]) continue;
+    meta = addPauseToMeta(meta, reason || "Switched job");
+    writeLogMeta(logSheet, i + 1, meta);
+    syncLegacyPauseCells(logSheet, i + 1, meta, logs[i][4]);
+    paused.push(String(logs[i][1]));
+  }
+  return paused;
+}
+
+function resumeWorkerLog(ss, workerName, orderNum) {
+  var logSheet = getSheetOrDie(ss, TAB_LOGS);
+  var logs = logSheet.getDataRange().getValues();
+  for (var i = logs.length - 1; i >= 1; i--) {
+    if (String(logs[i][1]) === String(orderNum) &&
+        String(logs[i][2]).trim() === String(workerName).trim() &&
+        !logs[i][6]) {
+      var meta = parseLogMeta(logs[i].length > 12 ? logs[i][12] : "");
+      meta = closeOpenPauseInMeta(meta, new Date());
+      writeLogMeta(logSheet, i + 1, meta);
+      syncLegacyPauseCells(logSheet, i + 1, meta, logs[i][4]);
+      return true;
+    }
+  }
+  return false;
+}
+
+function autoSwitchWeldersAfterPlate(ss, orderNum) {
+  var logSheet = getSheetOrDie(ss, TAB_LOGS);
+  var logs = logSheet.getDataRange().getValues();
+  var switched = [];
+  for (var i = 1; i < logs.length; i++) {
+    var role = String(logs[i][3]).trim();
+    if (String(logs[i][1]) !== String(orderNum)) continue;
+    if (role !== "Welding") continue;
+    if (logs[i][6]) continue;
+    var worker = String(logs[i][2]).trim();
+    var meta = parseLogMeta(logs[i].length > 12 ? logs[i][12] : "");
+    var isPaused = hasOpenPause(meta.pauses) || !!logs[i][9];
+    if (!isPaused) continue;
+
+    var pausedOthers = autoPauseWorkerOtherJobs(ss, worker, [orderNum], "Plate ready on " + orderNum, meta.batchId);
+    closeIndirectTasksForWorker(ss, worker);
+    resumeWorkerLog(ss, worker, orderNum);
+    var notice = {
+      type: "plate-ready",
+      worker: worker,
+      resumedOrder: String(orderNum),
+      pausedOrders: pausedOthers,
+      message: "Plate ready — you are back on order " + orderNum
+    };
+    setWorkerNotice(worker, notice);
+    switched.push(notice);
+  }
+  return switched;
+}
+
+function setWorkerNotice(worker, notice) {
+  CacheService.getScriptCache().put("notice_" + String(worker).trim().toLowerCase(), JSON.stringify(notice), 900);
+}
+
+function popWorkerNotice(workerName) {
+  var cache = CacheService.getScriptCache();
+  var key = "notice_" + String(workerName).trim().toLowerCase();
+  var v = cache.get(key);
+  if (!v) return null;
+  cache.remove(key);
+  try { return JSON.parse(v); } catch (e) { return null; }
+}
+
+function undoAutoSwitch(workerName) {
+  var cache = CacheService.getScriptCache();
+  var key = "notice_" + String(workerName).trim().toLowerCase();
+  var v = cache.get(key);
+  if (!v) return { success: false, message: "No recent auto-switch to undo." };
+  var notice;
+  try { notice = JSON.parse(v); } catch (e) { return { success: false, message: "Invalid notice." }; }
+  var ss = getSpreadsheet();
+  autoPauseWorkerOtherJobs(ss, workerName, notice.pausedOrders || [], "Still on previous job", "");
+  (notice.pausedOrders || []).forEach(function(ord) {
+    resumeWorkerLog(ss, workerName, ord);
+  });
+  cache.remove(key);
+  return { success: true };
+}
+
+function leaveBatchForOrder(workerName, keepOrder) {
+  var ss = getSpreadsheet();
+  var logSheet = getSheetOrDie(ss, TAB_LOGS);
+  var logs = logSheet.getDataRange().getValues();
+  var now = new Date();
+  var batchId = "";
+  for (var i = logs.length - 1; i >= 1; i--) {
+    if (String(logs[i][1]) === String(keepOrder) &&
+        String(logs[i][2]).trim() === String(workerName).trim() &&
+        !logs[i][6]) {
+      var meta = parseLogMeta(logs[i].length > 12 ? logs[i][12] : "");
+      batchId = meta.batchId;
+      break;
+    }
+  }
+  if (!batchId) return { success: true, message: "Not in a batch." };
+  for (var j = 1; j < logs.length; j++) {
+    var m = parseLogMeta(logs[j].length > 12 ? logs[j][12] : "");
+    if (m.batchId !== batchId || logs[j][6]) continue;
+    if (String(logs[j][2]).trim() !== String(workerName).trim()) continue;
+    if (!m.batchSplitAt) m.batchSplitAt = now.getTime();
+    if (String(logs[j][1]) !== String(keepOrder)) {
+      m = addPauseToMeta(m, "Batch cut done — assembling " + keepOrder);
+    }
+    writeLogMeta(logSheet, j + 1, m);
+    syncLegacyPauseCells(logSheet, j + 1, m, logs[j][4]);
+  }
+  return { success: true };
+}
+
+function ensureIdleTrigger() {
+  var triggers = ScriptApp.getProjectTriggers();
+  for (var i = 0; i < triggers.length; i++) {
+    if (triggers[i].getHandlerFunction() === "checkIdleWorkers") return;
+  }
+  ScriptApp.newTrigger("checkIdleWorkers").timeBased().everyMinutes(5).create();
+}
+
+function getIdleAlertSheet(ss) {
+  var sheet = ss.getSheetByName(TAB_IDLE);
+  if (!sheet) {
+    sheet = ss.insertSheet(TAB_IDLE);
+    sheet.appendRow(["Date", "Worker", "Role", "IdleSince", "AlertedAt", "Status", "AssignedTask"]);
+    sheet.hideSheet();
+  }
+  return sheet;
+}
+
+function workerHasRunningJob(logs, workerName) {
+  for (var i = 1; i < logs.length; i++) {
+    if (String(logs[i][2]).trim() !== String(workerName).trim()) continue;
+    if (logs[i][6]) continue;
+    var meta = parseLogMeta(logs[i].length > 12 ? logs[i][12] : "");
+    if (meta.entryType === "indirect") continue;
+    if (hasOpenPause(meta.pauses) || logs[i][9]) continue;
+    return true;
+  }
+  return false;
+}
+
+function workerHasOpenIndirect(logs, workerName) {
+  for (var i = 1; i < logs.length; i++) {
+    if (String(logs[i][2]).trim() !== String(workerName).trim()) continue;
+    if (logs[i][6]) continue;
+    var meta = parseLogMeta(logs[i].length > 12 ? logs[i][12] : "");
+    if (meta.entryType === "indirect" || String(logs[i][3]).trim() === "Indirect") return true;
+  }
+  return false;
+}
+
+function lastActivityMs(logs, workerName) {
+  var latest = 0;
+  for (var i = 1; i < logs.length; i++) {
+    if (String(logs[i][2]).trim() !== String(workerName).trim()) continue;
+    var start = logs[i][5] ? new Date(logs[i][5]).getTime() : 0;
+    var end = logs[i][6] ? new Date(logs[i][6]).getTime() : 0;
+    if (start > latest) latest = start;
+    if (end > latest) latest = end;
+  }
+  return latest;
+}
+
+function alreadyAlertedToday(idleSheet, workerName) {
+  var today = sastDayStamp(new Date());
+  var data = idleSheet.getDataRange().getValues();
+  for (var i = 1; i < data.length; i++) {
+    if (String(data[i][1]).trim() === String(workerName).trim() &&
+        String(data[i][0]) === today &&
+        String(data[i][5]).toLowerCase() !== "resolved") {
+      return true;
+    }
+  }
+  return false;
+}
+
+function checkIdleWorkers() {
+  if (!isWithinShiftNow()) return;
+  var ss = getSpreadsheet();
+  var logSheet = getSheetOrDie(ss, TAB_LOGS);
+  var logs = logSheet.getDataRange().getValues();
+  var users = getUsersAndRoles();
+  var idleSheet = getIdleAlertSheet(ss);
+  var now = new Date();
+  var graceMs = IDLE_GRACE_MINS * 60 * 1000;
+  var alerted = [];
+
+  for (var u = 0; u < users.length; u++) {
+    var name = users[u].name;
+    var role = users[u].role;
+    if (!name || String(role).toLowerCase() === "admin") continue;
+    if (workerHasRunningJob(logs, name)) continue;
+    if (workerHasOpenIndirect(logs, name)) continue;
+    var last = lastActivityMs(logs, name);
+    if (last && (now.getTime() - last) < graceMs) continue;
+    if (alreadyAlertedToday(idleSheet, name)) continue;
+
+    idleSheet.appendRow([
+      sastDayStamp(now),
+      name,
+      role,
+      last ? new Date(last) : "",
+      now,
+      "Open",
+      ""
+    ]);
+    alerted.push(name + " (" + role + ")");
+  }
+
+  if (alerted.length > 0 && ALERT_EMAIL_RECIPIENT) {
+    try {
+      MailApp.sendEmail({
+        to: ALERT_EMAIL_RECIPIENT,
+        subject: "Idle workers need a task assigned (" + alerted.length + ")",
+        htmlBody: "<p>The following workers have no running job during shift hours:</p><ul><li>" +
+                  alerted.join("</li><li>") +
+                  "</li></ul><p>Open Studio Delta Production → Activity / Idle workers and assign a non-order task.</p>"
+      });
+    } catch (e) {
+      Logger.log("Idle email failed: " + e);
+    }
+  }
+}
+
+function getIdleWorkers() {
+  var ss = getSpreadsheet();
+  var idleSheet = getIdleAlertSheet(ss);
+  var data = idleSheet.getDataRange().getValues();
+  var today = sastDayStamp(new Date());
+  var list = [];
+  for (var i = 1; i < data.length; i++) {
+    if (String(data[i][0]) === today && String(data[i][5]).toLowerCase() === "open") {
+      list.push({
+        row: i + 1,
+        worker: data[i][1],
+        role: data[i][2],
+        idleSince: data[i][3] ? new Date(data[i][3]).getTime() : null,
+        alertedAt: data[i][4] ? new Date(data[i][4]).getTime() : null
+      });
+    }
+  }
+  return { workers: list, tasks: INDIRECT_TASKS };
+}
+
+function assignIndirectTask(workerName, taskName, assignedBy) {
+  if (!workerName || !taskName) return { success: false, message: "Worker and task are required." };
+  var ss = getSpreadsheet();
+  var logSheet = getSheetOrDie(ss, TAB_LOGS);
+  var logs = logSheet.getDataRange().getValues();
+  if (workerHasRunningJob(logs, workerName)) {
+    return { success: false, message: workerName + " already has a running job." };
+  }
+  closeIndirectTasksForWorker(ss, workerName);
+
+  var uniqueId = Utilities.getUuid();
+  var meta = defaultLogMeta();
+  meta.entryType = "indirect";
+  logSheet.appendRow([
+    uniqueId,
+    "INDIRECT",
+    workerName,
+    "Indirect",
+    taskName,
+    new Date(),
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    JSON.stringify(meta)
+  ]);
+
+  var idleSheet = getIdleAlertSheet(ss);
+  var data = idleSheet.getDataRange().getValues();
+  var today = sastDayStamp(new Date());
+  for (var i = 1; i < data.length; i++) {
+    if (String(data[i][1]).trim() === String(workerName).trim() &&
+        String(data[i][0]) === today &&
+        String(data[i][5]).toLowerCase() === "open") {
+      idleSheet.getRange(i + 1, 6).setValue("Assigned");
+      idleSheet.getRange(i + 1, 7).setValue(taskName);
+    }
+  }
+  return { success: true };
+}
+
+function getActivityReport(period, refDateMs, workerFilter) {
+  var ss = getSpreadsheet();
+  var logSheet = getSheetOrDie(ss, TAB_LOGS);
+  var logData = logSheet.getDataRange().getValues();
+  var ref = refDateMs ? new Date(Number(refDateMs)) : new Date();
+  var refStamp = sastDayStamp(ref);
+  var refWeek = Utilities.formatDate(ref, TZ_JOBURG, "yyyy-'W'ww");
+  var refMonth = Utilities.formatDate(ref, TZ_JOBURG, "yyyy-MM");
+
+  function inRange(dateObj) {
+    if (!dateObj) return false;
+    if (period === "day") return sastDayStamp(dateObj) === refStamp;
+    if (period === "week") return Utilities.formatDate(dateObj, TZ_JOBURG, "yyyy-'W'ww") === refWeek;
+    return Utilities.formatDate(dateObj, TZ_JOBURG, "yyyy-MM") === refMonth;
+  }
+
+  var byWorker = {};
+  var allWorkerNames = {};
+  for (var i = 1; i < logData.length; i++) {
+    var worker = String(logData[i][2] || "").trim();
+    if (!worker) continue;
+    var start = logData[i][5] ? new Date(logData[i][5]) : null;
+    var end = logData[i][6] ? new Date(logData[i][6]) : new Date();
+    var anchor = logData[i][6] ? new Date(logData[i][6]) : start;
+    if (!anchor || isNaN(anchor) || !inRange(anchor)) continue;
+    allWorkerNames[worker] = true;
+    if (workerFilter && String(workerFilter).trim() && String(workerFilter).trim().toLowerCase() !== worker.toLowerCase()) continue;
+
+    var mins = calculateWorkMinutesFromLog(logData[i]);
+    var dayStamp = sastDayStamp(anchor);
+    if (!byWorker[worker]) byWorker[worker] = { worker: worker, days: {}, tasks: [] };
+    if (!byWorker[worker].days[dayStamp]) {
+      byWorker[worker].days[dayStamp] = { date: dayStamp, minutes: 0, overtime: 0, regular: 0, tasks: [] };
+    }
+    var task = {
+      order: logData[i][1],
+      role: logData[i][3],
+      task: logData[i][4],
+      start: start ? start.getTime() : null,
+      end: logData[i][6] ? new Date(logData[i][6]).getTime() : null,
+      minutes: mins,
+      entryType: parseLogMeta(logData[i].length > 12 ? logData[i][12] : "").entryType || "production"
+    };
+    byWorker[worker].days[dayStamp].minutes += mins;
+    byWorker[worker].days[dayStamp].tasks.push(task);
+    byWorker[worker].tasks.push(task);
+  }
+
+  var workers = [];
+  var workerNames = Object.keys(byWorker).sort();
+  for (var w = 0; w < workerNames.length; w++) {
+    var rec = byWorker[workerNames[w]];
+    var days = [];
+    var dayKeys = Object.keys(rec.days).sort().reverse();
+    var totalMins = 0;
+    var totalOt = 0;
+    for (var d = 0; d < dayKeys.length; d++) {
+      var day = rec.days[dayKeys[d]];
+      day.overtime = Math.max(0, day.minutes - STANDARD_DAY_MINS);
+      day.regular = Math.min(day.minutes, STANDARD_DAY_MINS);
+      day.overLimit = day.minutes > STANDARD_DAY_MINS;
+      totalMins += day.minutes;
+      totalOt += day.overtime;
+      days.push(day);
+    }
+    rec.tasks.sort(function(a, b) { return (b.start || 0) - (a.start || 0); });
+    workers.push({
+      worker: rec.worker,
+      days: days,
+      tasks: rec.tasks,
+      totalMinutes: totalMins,
+      totalRegular: Math.max(0, totalMins - totalOt),
+      totalOvertime: totalOt
+    });
+  }
+
+  return {
+    period: period,
+    refDate: ref.getTime(),
+    label: period === "day" ? refStamp : (period === "week" ? refWeek : refMonth),
+    standardDayMins: STANDARD_DAY_MINS,
+    allWorkerNames: Object.keys(allWorkerNames).sort(),
+    workers: workers
+  };
+}

--- a/studio-delta-production/Code.gs
+++ b/studio-delta-production/Code.gs
@@ -1362,8 +1362,53 @@ function formatDurationServer(totalMins) {
 }
 
 // --- ADMIN: FETCH ALL DATA ---
+function weekLabelSast(date) {
+  if (!date) return "Unknown Week";
+  return Utilities.formatDate(date, TZ_JOBURG, "yyyy - 'Week' ww");
+}
+
+function getDashboardDaySlices(row) {
+  var start = row[5] ? new Date(row[5]) : null;
+  if (start && isNaN(start.getTime())) start = null;
+  if (!start) return [];
+  var raw = splitWorkByDay(row, null, null);
+  var byDay = {};
+  var order = [];
+  for (var i = 0; i < raw.length; i++) {
+    var s = raw[i];
+    var stamp = s.dayStamp;
+    if (!stamp) continue;
+    if (!byDay[stamp]) {
+      byDay[stamp] = {
+        date: stamp,
+        start: s.start ? s.start.getTime() : null,
+        end: s.end ? s.end.getTime() : null,
+        durationMins: s.mins || 0,
+        week: weekLabelSast(s.start || start),
+        stillRunning: !!s.stillRunning,
+        stopReason: s.stopReason || ""
+      };
+      order.push(stamp);
+    } else {
+      var rec = byDay[stamp];
+      rec.durationMins += (s.mins || 0);
+      if (s.start && (rec.start === null || s.start.getTime() < rec.start)) rec.start = s.start.getTime();
+      if (s.stillRunning) {
+        rec.stillRunning = true;
+        rec.end = null;
+      } else if (!rec.stillRunning && s.end && (rec.end === null || s.end.getTime() > rec.end)) {
+        rec.end = s.end.getTime();
+      }
+      if (s.stopReason) rec.stopReason = s.stopReason;
+    }
+  }
+  var out = [];
+  for (var j = 0; j < order.length; j++) out.push(byDay[order[j]]);
+  return out;
+}
+
 function getAdminDashboardData() {
-  var cached = floorCacheGet("adminDash");
+  var cached = floorCacheGet("adminDash:v2");
   if (cached) return cached;
   var ss = getSpreadsheet();
   
@@ -1379,6 +1424,9 @@ function getAdminDashboardData() {
     var endObj = row[6] ? new Date(row[6]) : null;
     if (endObj && isNaN(endObj.getTime())) endObj = null;
     var openStart = getOpenPauseStart(meta);
+    var daySlices = getDashboardDaySlices(row);
+    var sliceTotal = 0;
+    for (var si = 0; si < daySlices.length; si++) sliceTotal += daySlices[si].durationMins;
     
     return {
       order: row[1],
@@ -1395,8 +1443,9 @@ function getAdminDashboardData() {
       batchShare: meta.batchShare || 1,
       batchSplitAt: meta.batchSplitAt || null,
       entryType: meta.entryType || "production",
-      durationMins: calculateWorkMinutesFromLog(row),
-      week: weekStr
+      durationMins: daySlices.length ? sliceTotal : calculateWorkMinutesFromLog(row),
+      week: weekStr,
+      daySlices: daySlices
     };
   });
 
@@ -1418,7 +1467,7 @@ function getAdminDashboardData() {
   }
 
   var adminPayload = { logs: logs, orders: orders };
-  floorCachePut("adminDash", adminPayload, CACHE_TTL_ADMIN);
+  floorCachePut("adminDash:v2", adminPayload, CACHE_TTL_ADMIN);
   return adminPayload;
 }
 

--- a/studio-delta-production/Code.gs
+++ b/studio-delta-production/Code.gs
@@ -162,8 +162,8 @@ function workerCanPerformTask(workerName, task) {
   if (profile.isAdmin) return true;
   var want = canonicalTaskName(task) || String(task || "").trim();
   if (profile.tasks.indexOf(want) !== -1) return true;
-  // Assemblers may start Paint Preparation from Ready for Assembly without a separate login task.
-  if (want === "Paint Preparation" && profile.tasks.indexOf("Assembly") !== -1) return true;
+  // Assemblers and painters may start Paint Preparation without a separate login task.
+  if (want === "Paint Preparation" && (profile.tasks.indexOf("Assembly") !== -1 || profile.tasks.indexOf("Painting") !== -1)) return true;
   return false;
 }
 
@@ -609,7 +609,7 @@ function getOrdersForRole(role, workerName) {
     ],
     'Assembly': ['Ready for Assembly', 'Assembly', 'Paint Preparation'],
     'Paint Preparation': ['Ready for Assembly', 'Paint Preparation'],
-    'Painting': ['Ready for Painting', 'Painting']
+    'Painting': ['Ready for Assembly', 'Paint Preparation', 'Ready for Painting', 'Painting']
   };
 
   var plateCuttingStages = [
@@ -1612,7 +1612,7 @@ function getStartStatusForRole(currentStatus, role) {
   var currentLower = String(currentStatus || "").trim().toLowerCase();
   var roleLower = String(role || "").trim().toLowerCase();
   if (roleLower === "plate cutting") return "Plate Cutting";
-  if (currentLower === "ready for assembly" && roleLower === "paint preparation") {
+  if (currentLower === "ready for assembly" && (roleLower === "paint preparation" || roleLower === "painting" || roleLower === "painter")) {
     return "Paint Preparation";
   }
   if (currentLower === "ready for painting" && (roleLower === "painting" || roleLower === "painter")) {

--- a/studio-delta-production/Code.gs
+++ b/studio-delta-production/Code.gs
@@ -380,6 +380,7 @@ function packValuesIndex(pack, sheetRow) {
 }
 
 var CACHE_TTL_FLOOR = 90;
+var CACHE_TTL_ACTIVITY = 45;
 var CACHE_TTL_USERS = 180;
 var CACHE_TTL_STEEL = 300;
 var CACHE_TTL_BACKBOARD = 300;
@@ -918,8 +919,7 @@ function finishOrder(rowIndex, logId, qcData, signatureUrl, filesData, workerNam
     logSheet.getRange(rowToUpdate, 7).setValue(endTime);
     logSheet.getRange(rowToUpdate, 8).setValue(resultStr);
     if(signatureUrl) logSheet.getRange(rowToUpdate, 9).setValue(signatureUrl);
-    writeLogMeta(logSheet, rowToUpdate, meta);
-    syncLegacyPauseCells(logSheet, rowToUpdate, meta, processName);
+    writeLogPauseState(logSheet, rowToUpdate, meta, processName);
 
     SpreadsheetApp.flush();
 
@@ -2004,8 +2004,7 @@ function workerPauseOrder(rowIndex, orderNum, workerName, reason) {
          if (!hasOpenPause(meta.pauses) && !logs[i][9]) {
             var sheetRow = packSheetRow(pack, i);
             meta = addPauseToMeta(meta, reason);
-            writeLogMeta(logSheet, sheetRow, meta);
-            syncLegacyPauseCells(logSheet, sheetRow, meta, logs[i][4]);
+            writeLogPauseState(logSheet, sheetRow, meta, logs[i][4]);
             pausedSomething = true;
          }
       }
@@ -2058,8 +2057,7 @@ function adminPauseOrder(orderNum) {
          if (!hasOpenPause(meta.pauses) && !logs[i][9]) {
             var sheetRow = packSheetRow(pack, i);
             meta = addPauseToMeta(meta, "Admin pause");
-            writeLogMeta(logSheet, sheetRow, meta);
-            syncLegacyPauseCells(logSheet, sheetRow, meta, logs[i][4]);
+            writeLogPauseState(logSheet, sheetRow, meta, logs[i][4]);
             pausedSomething = true;
          }
       }
@@ -2088,8 +2086,7 @@ function adminResumeOrder(orderNum) {
          if (hasOpenPause(meta.pauses) || logs[i][9]) {
             var sheetRow = packSheetRow(pack, i);
             meta = closeOpenPauseInMeta(meta, new Date());
-            writeLogMeta(logSheet, sheetRow, meta);
-            syncLegacyPauseCells(logSheet, sheetRow, meta, logs[i][4]);
+            writeLogPauseState(logSheet, sheetRow, meta, logs[i][4]);
             resumedSomething = true;
          }
       }
@@ -2332,6 +2329,21 @@ function writeLogMeta(logSheet, rowNum, meta) {
   logSheet.getRange(rowNum, 13).setValue(JSON.stringify(meta));
 }
 
+function writeLogPauseState(logSheet, rowNum, meta, taskName) {
+  meta = meta || defaultLogMeta();
+  var openStart = getOpenPauseStart(meta);
+  var lastReason = "";
+  if (meta.pauses && meta.pauses.length) {
+    lastReason = meta.pauses[meta.pauses.length - 1].reason || "";
+  }
+  logSheet.getRange(rowNum, 10, 1, 4).setValues([[
+    openStart ? new Date(openStart) : "",
+    cumulativePauseMinsFromMeta(meta, taskName),
+    openStart ? lastReason : "",
+    JSON.stringify(meta)
+  ]]);
+}
+
 function asSast(date) {
   return new Date(date.getTime() + SAST_OFFSET_MS);
 }
@@ -2476,24 +2488,35 @@ function getWorkBoutsFromLog(row) {
   return bouts;
 }
 
-function splitWorkByDay(row) {
+function splitWorkByDay(row, rangeFrom, rangeTo) {
   var task = row[4];
   var emptyMeta = defaultLogMeta();
   var slices = [];
+  var rangeFromMs = rangeFrom ? rangeFrom.getTime() : 0;
+  var rangeToMs = rangeTo ? rangeTo.getTime() : 0;
   var bouts = getWorkBoutsFromLog(row);
   for (var b = 0; b < bouts.length; b++) {
     var bout = bouts[b];
-    var endStamp = sastDayStamp(bout.end);
-    var cursor = sastWallToDate(bout.start, 0, 0);
+    var boutStartMs = bout.start.getTime();
+    var boutEndMs = bout.end.getTime();
+    if (rangeToMs && boutStartMs >= rangeToMs) continue;
+    if (rangeFromMs && boutEndMs <= rangeFromMs) continue;
+    if (rangeFromMs && boutStartMs < rangeFromMs) boutStartMs = rangeFromMs;
+    if (rangeToMs && boutEndMs > rangeToMs) boutEndMs = rangeToMs;
+    if (boutEndMs <= boutStartMs) continue;
+    var clippedStart = new Date(boutStartMs);
+    var clippedEnd = new Date(boutEndMs);
+    var endStamp = sastDayStamp(clippedEnd);
+    var cursor = sastWallToDate(clippedStart, 0, 0);
     var safety = 0;
     var daySlices = [];
-    while (sastDayStamp(cursor) <= endStamp && safety < 400) {
+    while (sastDayStamp(cursor) <= endStamp && safety < 40) {
       safety++;
       var dayStamp = sastDayStamp(cursor);
       var dayStart = sastWallToDate(cursor, 0, 0);
       var nextMidnight = addSastDays(dayStart, 1);
-      var sliceStartMs = Math.max(bout.start.getTime(), dayStart.getTime());
-      var sliceEndMs = Math.min(bout.end.getTime(), nextMidnight.getTime());
+      var sliceStartMs = Math.max(clippedStart.getTime(), dayStart.getTime());
+      var sliceEndMs = Math.min(clippedEnd.getTime(), nextMidnight.getTime());
       if (sliceEndMs > sliceStartMs) {
         var sliceStart = new Date(sliceStartMs);
         var sliceEnd = new Date(sliceEndMs);
@@ -2512,13 +2535,31 @@ function splitWorkByDay(row) {
       cursor = addSastDays(cursor, 1);
     }
     if (daySlices.length) {
-      daySlices[daySlices.length - 1].stopReason = bout.stopReason || "";
-      daySlices[daySlices.length - 1].stillRunning = !!bout.stillRunning;
-      if (bout.stillRunning) daySlices[daySlices.length - 1].end = null;
+      var pauseInRange = !rangeToMs || bout.end.getTime() <= rangeToMs;
+      var still = !!bout.stillRunning && (!rangeToMs || bout.end.getTime() <= rangeToMs);
+      daySlices[daySlices.length - 1].stopReason = pauseInRange ? (bout.stopReason || "") : "";
+      daySlices[daySlices.length - 1].stillRunning = still;
+      if (still) daySlices[daySlices.length - 1].end = null;
     }
     for (var s = 0; s < daySlices.length; s++) slices.push(daySlices[s]);
   }
   return slices;
+}
+
+function getActivityPeriodBounds(period, ref) {
+  var day0 = sastWallToDate(ref, 0, 0);
+  if (period === "day") {
+    return { from: day0, to: addSastDays(day0, 1) };
+  }
+  if (period === "month") {
+    var ym = Utilities.formatDate(ref, TZ_JOBURG, "yyyy-MM").split("-");
+    var y = Number(ym[0]);
+    var m = Number(ym[1]);
+    var from = sastWallToDate(new Date(Date.UTC(y, m - 1, 1, 10, 0, 0)), 0, 0);
+    var next = m === 12 ? new Date(Date.UTC(y + 1, 0, 1, 10, 0, 0)) : new Date(Date.UTC(y, m, 1, 10, 0, 0));
+    return { from: from, to: sastWallToDate(next, 0, 0) };
+  }
+  return { from: addSastDays(day0, -8), to: addSastDays(day0, 8) };
 }
 
 function hasOpenPause(pauses) {
@@ -2669,8 +2710,7 @@ function closeIndirectTasksForWorker(ss, workerName, pack) {
       var sheetRow = packSheetRow(pack, i);
       meta = closeOpenPauseInMeta(meta, now);
       logSheet.getRange(sheetRow, 7).setValue(now);
-      writeLogMeta(logSheet, sheetRow, meta);
-      syncLegacyPauseCells(logSheet, sheetRow, meta, logs[i][4]);
+      writeLogPauseState(logSheet, sheetRow, meta, logs[i][4]);
       closed++;
     }
   }
@@ -2694,8 +2734,7 @@ function autoPauseWorkerOtherJobs(ss, workerName, exceptOrders, reason, exceptBa
     if (hasOpenPause(meta.pauses) || logs[i][9]) continue;
     var sheetRow = packSheetRow(pack, i);
     meta = addPauseToMeta(meta, reason || "Switched job");
-    writeLogMeta(logSheet, sheetRow, meta);
-    syncLegacyPauseCells(logSheet, sheetRow, meta, logs[i][4]);
+    writeLogPauseState(logSheet, sheetRow, meta, logs[i][4]);
     paused.push(String(logs[i][1]));
   }
   return paused;
@@ -2712,8 +2751,7 @@ function resumeWorkerLog(ss, workerName, orderNum, pack) {
       var sheetRow = packSheetRow(pack, i);
       var meta = parseLogMeta(logs[i].length > 12 ? logs[i][12] : "");
       meta = closeOpenPauseInMeta(meta, new Date());
-      writeLogMeta(logSheet, sheetRow, meta);
-      syncLegacyPauseCells(logSheet, sheetRow, meta, logs[i][4]);
+      writeLogPauseState(logSheet, sheetRow, meta, logs[i][4]);
       return true;
     }
   }
@@ -2805,8 +2843,7 @@ function leaveBatchForOrder(workerName, keepOrder) {
       m = addPauseToMeta(m, "Batch cut done — assembling " + keepOrder);
     }
     var sheetRow = packSheetRow(pack, j);
-    writeLogMeta(logSheet, sheetRow, m);
-    syncLegacyPauseCells(logSheet, sheetRow, m, logs[j][4]);
+    writeLogPauseState(logSheet, sheetRow, m, logs[j][4]);
   }
   bumpFloorCache();
   return { success: true };
@@ -3014,13 +3051,21 @@ function assignIndirectTask(workerName, taskName, assignedBy) {
 }
 
 function getActivityReport(period, refDateMs, workerFilter) {
-  var ss = getSpreadsheet();
-  var logSheet = getSheetOrDie(ss, TAB_LOGS);
-  var logData = logSheet.getDataRange().getValues();
   var ref = refDateMs ? new Date(Number(refDateMs)) : new Date();
   var refStamp = sastDayStamp(ref);
   var refWeek = Utilities.formatDate(ref, TZ_JOBURG, "yyyy-'W'ww");
   var refMonth = Utilities.formatDate(ref, TZ_JOBURG, "yyyy-MM");
+  var cacheKey = "activity:" + String(period || "day") + ":" + (period === "day" ? refStamp : (period === "week" ? refWeek : refMonth)) + ":" + String(workerFilter || "").trim().toLowerCase();
+  var cached = floorCacheGet(cacheKey);
+  if (cached) return cached;
+  var ss = getSpreadsheet();
+  var logSheet = getSheetOrDie(ss, TAB_LOGS);
+  var lastRow = logSheet.getLastRow();
+  var lastCol = Math.min(13, logSheet.getLastColumn());
+  var logData = lastRow < 2 ? [[]] : logSheet.getRange(1, 1, lastRow, lastCol).getValues();
+  var bounds = getActivityPeriodBounds(period, ref);
+  var fromMs = bounds.from.getTime();
+  var toMs = bounds.to.getTime();
 
   function inRange(dateObj) {
     if (!dateObj) return false;
@@ -3046,8 +3091,12 @@ function getActivityReport(period, refDateMs, workerFilter) {
     if (!worker) continue;
     var start = logData[i][5] ? new Date(logData[i][5]) : null;
     if (!start || isNaN(start.getTime())) continue;
+    var end = logData[i][6] ? new Date(logData[i][6]) : new Date();
+    if (end && isNaN(end.getTime())) end = new Date();
+    if (start.getTime() >= toMs) continue;
+    if (end.getTime() <= fromMs) continue;
 
-    var slices = splitWorkByDay(logData[i]);
+    var slices = splitWorkByDay(logData[i], bounds.from, bounds.to);
     var anyInRange = false;
     for (var s = 0; s < slices.length; s++) {
       if (inRangeStamp(slices[s].dayStamp)) { anyInRange = true; break; }
@@ -3110,7 +3159,7 @@ function getActivityReport(period, refDateMs, workerFilter) {
     });
   }
 
-  return {
+  var result = {
     period: period,
     refDate: ref.getTime(),
     label: period === "day" ? refStamp : (period === "week" ? refWeek : refMonth),
@@ -3118,4 +3167,6 @@ function getActivityReport(period, refDateMs, workerFilter) {
     allWorkerNames: Object.keys(allWorkerNames).sort(),
     workers: workers
   };
+  floorCachePut(cacheKey, result, CACHE_TTL_ACTIVITY);
+  return result;
 }

--- a/studio-delta-production/Code.gs
+++ b/studio-delta-production/Code.gs
@@ -683,7 +683,7 @@ function pollFloor(role, workerName) {
   };
 }
 
-function startOrder(rowIndex, workerName, role, batchRowIndices) {
+function startOrder(rowIndex, workerName, role, batchRowIndices, switchReason) {
   var lock = LockService.getScriptLock();
   lock.waitLock(10000); 
   
@@ -710,8 +710,6 @@ function startOrder(rowIndex, workerName, role, batchRowIndices) {
       throw new Error(workerName + " is not assigned to " + role + ". Ask admin to add it on the Users sheet.");
     }
 
-    closeIndirectTasksForWorker(ss, workerName, pack);
-
     var batchId = rowsToStart.length > 1 ? Utilities.getUuid() : "";
     var batchShare = rowsToStart.length > 1 ? rowsToStart.length : 1;
     var exceptOrders = [];
@@ -720,10 +718,15 @@ function startOrder(rowIndex, workerName, role, batchRowIndices) {
       exceptOrders.push(orderData[er - 1] ? orderData[er - 1][1] : "");
     }
 
-    var pauseReason = (role === "Welding")
-      ? ("Waiting for plate / switched to " + exceptOrders[0])
-      : ("Switched to order " + exceptOrders[0]);
-    autoPauseWorkerOtherJobs(ss, workerName, exceptOrders, pauseReason, batchId, pack);
+    var runningOthers = listRunningOrdersForWorker(pack.values, workerName, exceptOrders);
+    if (runningOthers.length && !isUserPauseReason(switchReason)) {
+      return { success: false, needsSwitchReason: true, runningOrders: runningOthers, message: "Choose why you are leaving the current order." };
+    }
+
+    closeIndirectTasksForWorker(ss, workerName, pack);
+    if (runningOthers.length) {
+      autoPauseWorkerOtherJobs(ss, workerName, exceptOrders, switchReason, batchId, pack);
+    }
 
     var started = [];
     var startTime = new Date();
@@ -1961,9 +1964,9 @@ function generatePowderCoatingList(listData, workerName) {
   }
 }
 
-function batchStartOrders(rowIndices, workerName, role) {
+function batchStartOrders(rowIndices, workerName, role, switchReason) {
   try {
-    return startOrder(rowIndices[0], workerName, role, rowIndices);
+    return startOrder(rowIndices[0], workerName, role, rowIndices, switchReason);
   } catch(e) {
     Logger.log("Batch start error: " + e);
     return {success: false, error: e.toString()};
@@ -1987,6 +1990,9 @@ function workerPauseOrder(rowIndex, orderNum, workerName, reason) {
   var lock = LockService.getScriptLock();
   lock.waitLock(10000);
   try {
+    if (!isUserPauseReason(reason)) {
+      return { success: false, message: "Choose a pause reason: No materials, Touch up (with order number), or Other." };
+    }
     var ss = getSpreadsheet();
     var logSheet = getSheetOrDie(ss, TAB_LOGS);
     var pack = getLogPack(ss);
@@ -2013,14 +2019,21 @@ function workerPauseOrder(rowIndex, orderNum, workerName, reason) {
   }
 }
 
-function workerResumeOrder(rowIndex, orderNum, workerName) {
+function workerResumeOrder(rowIndex, orderNum, workerName, switchReason) {
   var lock = LockService.getScriptLock();
   lock.waitLock(10000);
   try {
     var ss = getSpreadsheet();
-    autoPauseWorkerOtherJobs(ss, workerName, [orderNum], "Switched to order " + orderNum, "");
-    closeIndirectTasksForWorker(ss, workerName);
-    var ok = resumeWorkerLog(ss, workerName, orderNum);
+    var pack = getLogPack(ss);
+    var runningOthers = listRunningOrdersForWorker(pack.values, workerName, [orderNum]);
+    if (runningOthers.length && !isUserPauseReason(switchReason)) {
+      return { success: false, needsSwitchReason: true, runningOrders: runningOthers, message: "Choose why you are leaving the current order." };
+    }
+    if (runningOthers.length) {
+      autoPauseWorkerOtherJobs(ss, workerName, [orderNum], switchReason, "", pack);
+    }
+    closeIndirectTasksForWorker(ss, workerName, pack);
+    var ok = resumeWorkerLog(ss, workerName, orderNum, pack);
     if (!ok) return {success: false, message: "No paused tasks found for you on this order."};
     return {success: true};
   } catch(e) {
@@ -2422,7 +2435,7 @@ function calculateWorkMinutesFromLog(row) {
   return calculateWorkMinutesMeta(start, end, task, meta, row[10]);
 }
 
-function splitWorkByDay(row) {
+function getWorkBoutsFromLog(row) {
   var start = row[5] ? new Date(row[5]) : null;
   if (start && isNaN(start.getTime())) start = null;
   if (!start) return [];
@@ -2430,50 +2443,80 @@ function splitWorkByDay(row) {
   var end = row[6] ? new Date(row[6]) : new Date();
   if (end && isNaN(end.getTime())) end = new Date();
   if (end.getTime() <= start.getTime()) return [];
-  var task = row[4];
   var meta = parseLogMeta(row.length > 12 ? row[12] : "");
-  if (row[9] && !hasOpenPause(meta.pauses)) {
-    meta.pauses = getPauseIntervalsForRow(row);
-  }
-  var hasPauseTimes = meta.pauses && meta.pauses.length > 0;
-  var fullRaw = 0;
-  if (!hasPauseTimes && row[10]) {
-    fullRaw = calcRawServerMins(start, end, task);
-  }
-  var slices = [];
-  var endStamp = sastDayStamp(end);
-  var cursor = sastWallToDate(start, 0, 0);
-  var safety = 0;
-  while (sastDayStamp(cursor) <= endStamp && safety < 400) {
-    safety++;
-    var dayStamp = sastDayStamp(cursor);
-    var dayStart = sastWallToDate(cursor, 0, 0);
-    var nextMidnight = addSastDays(dayStart, 1);
-    var sliceStartMs = Math.max(start.getTime(), dayStart.getTime());
-    var sliceEndMs = Math.min(end.getTime(), nextMidnight.getTime());
-    if (sliceEndMs > sliceStartMs) {
-      var sliceStart = new Date(sliceStartMs);
-      var sliceEnd = new Date(sliceEndMs);
-      var mins = 0;
-      if (hasPauseTimes) {
-        mins = calculateWorkMinutesMeta(sliceStart, sliceEnd, task, meta, 0);
-      } else if (row[10] && fullRaw > 0) {
-        var sliceRaw = calcRawServerMins(sliceStart, sliceEnd, task);
-        mins = Math.max(0, sliceRaw - (parseFloat(row[10]) || 0) * (sliceRaw / fullRaw));
-      } else {
-        mins = calculateWorkMinutesMeta(sliceStart, sliceEnd, task, meta, 0);
-      }
-      if (mins > 0) {
-        var stillRunning = isOpen && dayStamp === sastDayStamp(end);
-        slices.push({
-          dayStamp: dayStamp,
-          start: sliceStart,
-          end: stillRunning ? null : sliceEnd,
-          mins: mins
-        });
-      }
+  var pauses = (meta.pauses && meta.pauses.length) ? meta.pauses.slice() : getPauseIntervalsForRow(row);
+  pauses.sort(function(a, b) { return new Date(a.start).getTime() - new Date(b.start).getTime(); });
+  var bouts = [];
+  var cursor = start.getTime();
+  var endMs = end.getTime();
+  for (var i = 0; i < pauses.length; i++) {
+    var ps = new Date(pauses[i].start).getTime();
+    if (isNaN(ps)) continue;
+    var pe = pauses[i].end ? new Date(pauses[i].end).getTime() : endMs;
+    if (isNaN(pe)) pe = endMs;
+    if (ps > cursor) {
+      bouts.push({
+        start: new Date(cursor),
+        end: new Date(Math.min(ps, endMs)),
+        stopReason: String(pauses[i].reason || ""),
+        stillRunning: false
+      });
     }
-    cursor = addSastDays(cursor, 1);
+    if (pe > cursor) cursor = pe;
+    if (cursor >= endMs) break;
+  }
+  if (endMs > cursor) {
+    bouts.push({
+      start: new Date(cursor),
+      end: new Date(endMs),
+      stopReason: "",
+      stillRunning: isOpen
+    });
+  }
+  return bouts;
+}
+
+function splitWorkByDay(row) {
+  var task = row[4];
+  var emptyMeta = defaultLogMeta();
+  var slices = [];
+  var bouts = getWorkBoutsFromLog(row);
+  for (var b = 0; b < bouts.length; b++) {
+    var bout = bouts[b];
+    var endStamp = sastDayStamp(bout.end);
+    var cursor = sastWallToDate(bout.start, 0, 0);
+    var safety = 0;
+    var daySlices = [];
+    while (sastDayStamp(cursor) <= endStamp && safety < 400) {
+      safety++;
+      var dayStamp = sastDayStamp(cursor);
+      var dayStart = sastWallToDate(cursor, 0, 0);
+      var nextMidnight = addSastDays(dayStart, 1);
+      var sliceStartMs = Math.max(bout.start.getTime(), dayStart.getTime());
+      var sliceEndMs = Math.min(bout.end.getTime(), nextMidnight.getTime());
+      if (sliceEndMs > sliceStartMs) {
+        var sliceStart = new Date(sliceStartMs);
+        var sliceEnd = new Date(sliceEndMs);
+        var mins = calculateWorkMinutesMeta(sliceStart, sliceEnd, task, emptyMeta, 0);
+        if (mins > 0) {
+          daySlices.push({
+            dayStamp: dayStamp,
+            start: sliceStart,
+            end: sliceEnd,
+            mins: mins,
+            stopReason: "",
+            stillRunning: false
+          });
+        }
+      }
+      cursor = addSastDays(cursor, 1);
+    }
+    if (daySlices.length) {
+      daySlices[daySlices.length - 1].stopReason = bout.stopReason || "";
+      daySlices[daySlices.length - 1].stillRunning = !!bout.stillRunning;
+      if (bout.stillRunning) daySlices[daySlices.length - 1].end = null;
+    }
+    for (var s = 0; s < daySlices.length; s++) slices.push(daySlices[s]);
   }
   return slices;
 }
@@ -2503,6 +2546,33 @@ function addPauseToMeta(meta, reason) {
     reason: reason || ""
   });
   return meta;
+}
+
+function isUserPauseReason(reason) {
+  var r = String(reason || "").trim();
+  if (r === "No materials") return true;
+  if (/^Touch up #\S+/i.test(r)) return true;
+  if (/^Other:\s+\S/.test(r)) return true;
+  return false;
+}
+
+function listRunningOrdersForWorker(logs, workerName, exceptOrders) {
+  var exceptMap = {};
+  (exceptOrders || []).forEach(function(o) { exceptMap[String(o)] = true; });
+  var running = [];
+  var seen = {};
+  for (var i = 1; i < logs.length; i++) {
+    if (logs[i][6]) continue;
+    if (String(logs[i][2] || "").trim() !== String(workerName || "").trim()) continue;
+    var meta = parseLogMeta(logs[i].length > 12 ? logs[i][12] : "");
+    if (meta.entryType === "indirect") continue;
+    if (hasOpenPause(meta.pauses) || logs[i][9]) continue;
+    var ord = String(logs[i][1] || "");
+    if (!ord || exceptMap[ord] || seen[ord]) continue;
+    seen[ord] = true;
+    running.push({ order: ord, task: logs[i][4], role: logs[i][3] });
+  }
+  return running;
 }
 
 function closeOpenPauseInMeta(meta, atTime) {
@@ -3003,6 +3073,7 @@ function getActivityReport(period, refDateMs, workerFilter) {
         end: slice.end ? slice.end.getTime() : null,
         minutes: slice.mins,
         date: dayStamp,
+        stopReason: slice.stopReason || "",
         entryType: rowMeta.entryType || "production"
       };
       byWorker[worker].days[dayStamp].minutes += slice.mins;

--- a/studio-delta-production/Code.gs
+++ b/studio-delta-production/Code.gs
@@ -22,6 +22,137 @@ var STANDARD_DAY_MINS = 8 * 60;
 var IDLE_GRACE_MINS = 10;
 var INDIRECT_TASKS = ["Cleaning", "Maintenance", "Material handling", "Waiting for materials", "Waiting for plate", "Meeting", "Training", "Other"];
 
+
+var KNOWN_FLOOR_TASKS = ["Profile Cutting", "Plate Cutting", "Tagging", "Welding", "Grinding", "Quality Control", "Assembly"];
+
+var TASK_ALIAS_MAP = {
+  "profile cutting": "Profile Cutting",
+  "profile cutter": "Profile Cutting",
+  "steelwork": "Profile Cutting",
+  "plate cutting": "Plate Cutting",
+  "plate cutter": "Plate Cutting",
+  "plate": "Plate Cutting",
+  "tagging": "Tagging",
+  "tagger": "Tagging",
+  "welding": "Welding",
+  "welder": "Welding",
+  "grinding": "Grinding",
+  "grinder": "Grinding",
+  "quality control": "Quality Control",
+  "qc": "Quality Control",
+  "final qc": "Quality Control",
+  "pre-powder": "Quality Control",
+  "powder coating": "Quality Control",
+  "assembly": "Assembly",
+  "assembler": "Assembly"
+};
+
+function ensureUsersSheetTasksColumn() {
+  var ss = getSpreadsheet();
+  var sheet = getSheetOrDie(ss, TAB_USERS);
+  var lastCol = Math.max(sheet.getLastColumn(), 1);
+  var headers = sheet.getRange(1, 1, 1, lastCol).getValues()[0];
+  var found = false;
+  for (var i = 0; i < headers.length; i++) {
+    if (String(headers[i]).trim().toLowerCase() === "tasks") {
+      found = true;
+      break;
+    }
+  }
+  if (!found) {
+    sheet.getRange(1, 4).setValue("Tasks");
+  }
+}
+
+function canonicalTaskName(raw) {
+  var s = String(raw || "").trim().toLowerCase().replace(/\s+/g, " ");
+  if (!s) return "";
+  if (TASK_ALIAS_MAP[s]) return TASK_ALIAS_MAP[s];
+  for (var i = 0; i < KNOWN_FLOOR_TASKS.length; i++) {
+    if (KNOWN_FLOOR_TASKS[i].toLowerCase() === s) return KNOWN_FLOOR_TASKS[i];
+  }
+  return "";
+}
+
+function parseUserTasks(roleCell, tasksCell) {
+  var role = String(roleCell || "").trim();
+  var extra = String(tasksCell || "").trim();
+  var roleLower = role.toLowerCase();
+  var isAdmin = roleLower === "admin";
+  if (isAdmin) {
+    return { isAdmin: true, isQcOnly: false, tasks: KNOWN_FLOOR_TASKS.slice(), jobTitle: role || "Admin" };
+  }
+
+  var found = [];
+  function addTask(name) {
+    if (!name) return;
+    if (found.indexOf(name) === -1) found.push(name);
+  }
+
+  var source = extra || role;
+  var parts = String(source).split(/[,/&+|]+/);
+  for (var p = 0; p < parts.length; p++) {
+    addTask(canonicalTaskName(parts[p]));
+  }
+
+  if (found.length === 0) {
+    var blob = String(source).toLowerCase();
+    var keys = Object.keys(TASK_ALIAS_MAP).sort(function(a, b) { return b.length - a.length; });
+    for (var k = 0; k < keys.length; k++) {
+      var key = keys[k];
+      var re = new RegExp("(^|[^a-z])" + key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "([^a-z]|$)", "i");
+      if (re.test(blob)) addTask(TASK_ALIAS_MAP[key]);
+    }
+  }
+
+  var qcOnlyRole = roleLower === "quality control" || roleLower === "qc";
+  if (qcOnlyRole) {
+    return { isAdmin: false, isQcOnly: true, tasks: ["Quality Control"], jobTitle: role || "Quality Control" };
+  }
+
+  var isQcOnly = found.length === 1 && found[0] === "Quality Control";
+  if (found.length === 0 && role) {
+    addTask(canonicalTaskName(role));
+  }
+  return { isAdmin: false, isQcOnly: isQcOnly, tasks: found, jobTitle: role || (found[0] || "") };
+}
+
+function readUserRowProfile(row) {
+  var name = String(row[0] || "").trim();
+  var parsed = parseUserTasks(row[1], row.length > 3 ? row[3] : "");
+  return {
+    name: name,
+    role: String(row[1] || "").trim(),
+    jobTitle: parsed.jobTitle,
+    isAdmin: parsed.isAdmin,
+    isQcOnly: parsed.isQcOnly,
+    tasks: parsed.tasks
+  };
+}
+
+function getUserProfileByName(workerName) {
+  var ss = getSpreadsheet();
+  var sheet = getSheetOrDie(ss, TAB_USERS);
+  var data = sheet.getDataRange().getValues();
+  var needle = String(workerName || "").trim().toLowerCase();
+  if (!needle) return null;
+  for (var i = 1; i < data.length; i++) {
+    if (String(data[i][0] || "").trim().toLowerCase() === needle) {
+      return readUserRowProfile(data[i]);
+    }
+  }
+  return null;
+}
+
+function workerCanPerformTask(workerName, task) {
+  var profile = getUserProfileByName(workerName);
+  if (!profile) return false;
+  if (profile.isAdmin) return true;
+  var want = canonicalTaskName(task) || String(task || "").trim();
+  return profile.tasks.indexOf(want) !== -1;
+}
+
+
 // --- STEP 1: CENTRALIZED STEEL PROFILE MANAGEMENT ---
 /**
  * Returns an array of all steel profile names from the hidden "Steel_Profiles" tab.
@@ -63,6 +194,7 @@ function getSteelProfiles() {
 
 function doGet() {
   try { ensureIdleTrigger(); } catch (e) {}
+  try { ensureUsersSheetTasksColumn(); } catch (e) {}
   return HtmlService.createTemplateFromFile('index')
     .evaluate()
     .setTitle('Studio Delta Production')
@@ -142,7 +274,17 @@ function getUsersAndRoles() {
   var data = sheet.getDataRange().getValues();
   if (data.length <= 1) return []; 
   data.shift(); // Remove header
-  return data.map(function(row) { return { name: row[0], role: row[1] }; });
+  return data.map(function(row) {
+    var profile = readUserRowProfile(row);
+    return {
+      name: profile.name,
+      role: profile.role,
+      jobTitle: profile.jobTitle,
+      isAdmin: profile.isAdmin,
+      isQcOnly: profile.isQcOnly,
+      tasks: profile.tasks
+    };
+  });
 }
 
 // Helper function for case-insensitive status comparison
@@ -198,6 +340,7 @@ function verifyLogin(role, name, password) {
 
 function verifyGlobalLogin(name, password) {
   var ss = getSpreadsheet();
+  try { ensureUsersSheetTasksColumn(); } catch (e) {}
   var sheet = getSheetOrDie(ss, TAB_USERS);
   var data = sheet.getDataRange().getValues();
   
@@ -217,11 +360,19 @@ function verifyGlobalLogin(name, password) {
     var rowPass = data[i][2];
 
     if (lowerName === rowName && rowName !== "") {
-      if (String(password) == String(rowPass)) {
-        return { success: true };
-      }
-      if (adminPassword && String(password) == String(adminPassword)) {
-        return { success: true };
+      var ok = String(password) == String(rowPass);
+      if (!ok && adminPassword && String(password) == String(adminPassword)) ok = true;
+      if (ok) {
+        var profile = readUserRowProfile(data[i]);
+        return {
+          success: true,
+          name: profile.name,
+          role: profile.role,
+          jobTitle: profile.jobTitle,
+          isAdmin: profile.isAdmin,
+          isQcOnly: profile.isQcOnly,
+          tasks: profile.tasks
+        };
       }
     }
   }
@@ -230,6 +381,9 @@ function verifyGlobalLogin(name, password) {
 }
 
 function getOrdersForRole(role, workerName) {
+  if (workerName && role && role !== "Admin" && !workerCanPerformTask(workerName, role)) {
+    return [];
+  }
   var ss = getSpreadsheet();
   var sheet = getSheetOrDie(ss, TAB_ORDERS);
   var data = sheet.getDataRange().getValues();
@@ -339,6 +493,10 @@ function startOrder(rowIndex, workerName, role, batchRowIndices) {
     }
     if (rowsToStart.indexOf(parseInt(rowIndex, 10)) === -1) {
       rowsToStart.unshift(parseInt(rowIndex, 10));
+    }
+
+    if (!workerCanPerformTask(workerName, role)) {
+      throw new Error(workerName + " is not assigned to " + role + ". Ask admin to add it on the Users sheet.");
     }
 
     closeIndirectTasksForWorker(ss, workerName);

--- a/studio-delta-production/Code.gs
+++ b/studio-delta-production/Code.gs
@@ -313,21 +313,64 @@ function getSheetOrDie(ss, tabName) {
   return sheet;
 }
 
+var _gridMemo = {};
 function getSheetGrid(ss, tabName, numCols) {
+  var key = tabName + ":" + String(numCols || 0);
+  if (_gridMemo[key]) return _gridMemo[key];
   var sheet = getSheetOrDie(ss, tabName);
   var lastRow = sheet.getLastRow();
   if (lastRow < 1) return [];
   var lastCol = sheet.getLastColumn();
   if (lastCol < 1) return [];
   var cols = numCols ? Math.min(numCols, lastCol) : lastCol;
-  return sheet.getRange(1, 1, lastRow, cols).getValues();
+  var values = sheet.getRange(1, 1, lastRow, cols).getValues();
+  _gridMemo[key] = values;
+  return values;
 }
 
-var CACHE_TTL_FLOOR = 20;
-var CACHE_TTL_USERS = 45;
+var LOG_SCAN_MAX = 1500;
+var _logPackMemo = null;
+var _logPackFull = false;
+
+function getLogPack(ss, forceFull) {
+  if (_logPackMemo && (!forceFull || _logPackFull)) return _logPackMemo;
+  var sheet = getSheetOrDie(ss, TAB_LOGS);
+  var lastRow = sheet.getLastRow();
+  var lastCol = sheet.getLastColumn();
+  if (lastRow < 1 || lastCol < 1) {
+    _logPackMemo = { values: [[]], fromRow: 2 };
+    _logPackFull = true;
+    return _logPackMemo;
+  }
+  var cols = Math.min(13, lastCol);
+  var header = sheet.getRange(1, 1, 1, cols).getValues();
+  if (lastRow === 1) {
+    _logPackMemo = { values: header, fromRow: 2 };
+    _logPackFull = true;
+    return _logPackMemo;
+  }
+  var from = 2;
+  if (!forceFull && (lastRow - 1) > LOG_SCAN_MAX) {
+    from = lastRow - LOG_SCAN_MAX + 1;
+  }
+  var body = sheet.getRange(from, 1, lastRow - from + 1, cols).getValues();
+  _logPackMemo = { values: header.concat(body), fromRow: from };
+  _logPackFull = (from === 2);
+  return _logPackMemo;
+}
+
+function packSheetRow(pack, valuesIndex) {
+  return pack.fromRow + valuesIndex - 1;
+}
+function packValuesIndex(pack, sheetRow) {
+  return sheetRow - pack.fromRow + 1;
+}
+
+var CACHE_TTL_FLOOR = 90;
+var CACHE_TTL_USERS = 180;
 var CACHE_TTL_STEEL = 300;
 var CACHE_TTL_BACKBOARD = 300;
-var CACHE_TTL_ADMIN = 25;
+var CACHE_TTL_ADMIN = 60;
 
 function floorCacheGen() {
   try { return CacheService.getScriptCache().get("floorGen") || "0"; } catch (e) { return "0"; }
@@ -385,8 +428,7 @@ function buildPlateStatusMap(logData) {
 }
 
 function getPlateCuttingStatus(ss, orderNum) {
-  var logData = getSheetGrid(ss, TAB_LOGS, 13);
-  var map = buildPlateStatusMap(logData);
+  var map = buildPlateStatusMap(getLogPack(ss).values);
   return map[String(orderNum)] || emptyPlateStatus();
 }
 
@@ -409,7 +451,6 @@ function clearPlateCuttingStatus(ss, orderNum) {
 function getUsersAndRoles() {
   var cached = floorCacheGet("users");
   if (cached) return cached;
-  lazySetup();
   var ss = getSpreadsheet();
   var data = getSheetGrid(ss, TAB_USERS, 4);
   if (data.length <= 1) return []; 
@@ -481,11 +522,10 @@ function verifyLogin(role, name, password) {
 }
 
 function verifyGlobalLogin(name, password) {
-  lazySetup();
   var ss = getSpreadsheet();
-  try { ensureUsersSheetTasksColumn(); } catch (e) {}
   var sheet = getSheetOrDie(ss, TAB_USERS);
-  var data = sheet.getDataRange().getValues();
+  var data = getSheetGrid(ss, TAB_USERS, 4);
+  if (!data.length) data = sheet.getDataRange().getValues();
   
   // 1. Find the Admin Password first (Master Key)
   var adminPassword = null;
@@ -527,13 +567,12 @@ function getOrdersForRole(role, workerName) {
   if (workerName && role && role !== "Admin" && !workerCanPerformTask(workerName, role)) {
     return [];
   }
-  lazySetup();
   var cacheKey = "orders:" + String(role || "");
   var cached = floorCacheGet(cacheKey);
   if (cached) return cached;
   var ss = getSpreadsheet();
   var data = getSheetGrid(ss, TAB_ORDERS, 7);
-  var logData = getSheetGrid(ss, TAB_LOGS, 13);
+  var logData = getLogPack(ss).values;
   var activeAssignments = getActiveAssignmentsFromData(logData);
   var plateMap = (role === 'Plate Cutting') ? buildPlateStatusMap(logData) : {};
   var relevantOrders = [];
@@ -622,6 +661,13 @@ function getOrdersForRole(role, workerName) {
   return relevantOrders;
 }
 
+function pollFloor(role, workerName) {
+  return {
+    orders: getOrdersForRole(role, workerName),
+    notice: workerName ? popWorkerNotice(workerName) : null
+  };
+}
+
 function startOrder(rowIndex, workerName, role, batchRowIndices) {
   var lock = LockService.getScriptLock();
   lock.waitLock(10000); 
@@ -631,6 +677,8 @@ function startOrder(rowIndex, workerName, role, batchRowIndices) {
     var sheet = getSheetOrDie(ss, TAB_ORDERS);
     var logSheet = getSheetOrDie(ss, TAB_LOGS);
     var overviewSheet = ss.getSheetByName(TAB_OVERVIEW);
+    var orderData = getSheetGrid(ss, TAB_ORDERS, 7);
+    var pack = getLogPack(ss);
 
     var rowsToStart = [];
     if (batchRowIndices && batchRowIndices.length) {
@@ -647,27 +695,31 @@ function startOrder(rowIndex, workerName, role, batchRowIndices) {
       throw new Error(workerName + " is not assigned to " + role + ". Ask admin to add it on the Users sheet.");
     }
 
-    closeIndirectTasksForWorker(ss, workerName);
+    closeIndirectTasksForWorker(ss, workerName, pack);
 
     var batchId = rowsToStart.length > 1 ? Utilities.getUuid() : "";
     var batchShare = rowsToStart.length > 1 ? rowsToStart.length : 1;
     var exceptOrders = [];
     for (var e = 0; e < rowsToStart.length; e++) {
-      exceptOrders.push(sheet.getRange(rowsToStart[e], 2).getValue());
+      var er = rowsToStart[e];
+      exceptOrders.push(orderData[er - 1] ? orderData[er - 1][1] : "");
     }
 
     var pauseReason = (role === "Welding")
       ? ("Waiting for plate / switched to " + exceptOrders[0])
       : ("Switched to order " + exceptOrders[0]);
-    autoPauseWorkerOtherJobs(ss, workerName, exceptOrders, pauseReason, batchId);
+    autoPauseWorkerOtherJobs(ss, workerName, exceptOrders, pauseReason, batchId, pack);
 
     var started = [];
     var startTime = new Date();
+    var plateMap = (role === 'Plate Cutting') ? buildPlateStatusMap(pack.values) : {};
+    var activeAssignments = (role === 'Plate Cutting') ? {} : getActiveAssignmentsFromData(pack.values);
 
     for (var r = 0; r < rowsToStart.length; r++) {
       var thisRow = rowsToStart[r];
-      var orderNum = sheet.getRange(thisRow, 2).getValue();
-      var currentStatus = sheet.getRange(thisRow, 3).getValue();
+      var orderRow = orderData[thisRow - 1] || [];
+      var orderNum = orderRow[1];
+      var currentStatus = orderRow[2];
 
       var nextStatus = "";
       if (role === 'Plate Cutting') {
@@ -684,7 +736,7 @@ function startOrder(rowIndex, workerName, role, batchRowIndices) {
       }
 
       if (role === 'Plate Cutting') {
-        var plateInfo = getPlateCuttingStatus(ss, orderNum);
+        var plateInfo = plateMap[String(orderNum)] || emptyPlateStatus();
         if (plateInfo.assigned !== "" && plateInfo.assigned !== workerName) {
           throw new Error("Plate Cutting is already being done by " + plateInfo.assigned);
         }
@@ -693,7 +745,6 @@ function startOrder(rowIndex, workerName, role, batchRowIndices) {
           continue;
         }
       } else {
-        var activeAssignments = getActiveAssignments(ss); 
         var currentAssignment = activeAssignments[orderNum];
         var currentAssigned = currentAssignment ? currentAssignment.worker : ""; 
         if (currentAssigned !== "" && currentAssigned !== workerName) {
@@ -704,7 +755,7 @@ function startOrder(rowIndex, workerName, role, batchRowIndices) {
           continue;
         }
         if (currentAssigned === workerName && currentAssignment && currentAssignment.isPaused) {
-          resumeWorkerLog(ss, workerName, orderNum);
+          resumeWorkerLog(ss, workerName, orderNum, pack);
           started.push({ order: orderNum, rowIndex: thisRow, logId: currentAssignment.logId, newStatus: currentStatus, resumed: true });
           continue;
         }
@@ -717,8 +768,7 @@ function startOrder(rowIndex, workerName, role, batchRowIndices) {
       meta.entryType = "production";
 
       if (role !== 'Plate Cutting') {
-        sheet.getRange(thisRow, 3).setValue(nextStatus); 
-        sheet.getRange(thisRow, 4).setValue(workerName); 
+        sheet.getRange(thisRow, 3, 1, 2).setValues([[nextStatus, workerName]]);
       }
 
       logSheet.appendRow([
@@ -733,7 +783,6 @@ function startOrder(rowIndex, workerName, role, batchRowIndices) {
       started.push({ order: orderNum, rowIndex: thisRow, logId: uniqueId, newStatus: nextStatus });
     }
     
-    SpreadsheetApp.flush();
     return {
       success: true,
       newStatus: started[0] ? started[0].newStatus : "",
@@ -759,15 +808,19 @@ function finishOrder(rowIndex, logId, qcData, signatureUrl, filesData, workerNam
     var overviewSheet = ss.getSheetByName(TAB_OVERVIEW);
     var endTime = new Date(); 
     
-    var logs = logSheet.getDataRange().getValues();
+    var pack = getLogPack(ss);
     var orderNum = orderNumHint || sheet.getRange(rowIndex, 2).getValue();
-    var rowToUpdate = findOpenLogRow(logs, logId, orderNum, workerName);
+    var rowToUpdate = findOpenLogRow(pack, logId, orderNum, workerName);
+    if (rowToUpdate === -1) {
+      pack = getLogPack(ss, true);
+      rowToUpdate = findOpenLogRow(pack, logId, orderNum, workerName);
+    }
     
     if (rowToUpdate === -1) {
       throw new Error("Could not find active log entry for " + workerName + " on this order.");
     }
 
-    var logRow = logs[rowToUpdate-1];
+    var logRow = pack.values[packValuesIndex(pack, rowToUpdate)];
     var role = logRow[3];
     var processName = logRow[4];
     var startTime = logRow[5] ? new Date(logRow[5]) : null;
@@ -1312,22 +1365,20 @@ function formatDurationServer(totalMins) {
 function getAdminDashboardData() {
   var cached = floorCacheGet("adminDash");
   if (cached) return cached;
-  lazySetup();
   var ss = getSpreadsheet();
   
-  // 1. Get Logs
-  var logSheet = getSheetOrDie(ss, TAB_LOGS);
-  var logData = logSheet.getDataRange().getValues();
-  logData.shift(); 
+  var logData = getLogPack(ss).values.slice(1);
   var logs = logData.map(function(row) {
+    var meta = parseLogMeta(row.length > 12 ? row[12] : "");
     var ts = row[6] ? new Date(row[6]) : (row[5] ? new Date(row[5]) : null);
-    if (ts && isNaN(ts.getTime())) ts = null; // Guard against Invalid Date
+    if (ts && isNaN(ts.getTime())) ts = null;
     var weekStr = ts ? Utilities.formatDate(ts, "Africa/Johannesburg", "yyyy - 'Week' ww") : "Unknown Week";
     
     var startObj = row[5] ? new Date(row[5]) : null;
     if (startObj && isNaN(startObj.getTime())) startObj = null;
     var endObj = row[6] ? new Date(row[6]) : null;
     if (endObj && isNaN(endObj.getTime())) endObj = null;
+    var openStart = getOpenPauseStart(meta);
     
     return {
       order: row[1],
@@ -1337,31 +1388,19 @@ function getAdminDashboardData() {
       start: startObj ? startObj.getTime() : null,
       end: endObj ? endObj.getTime() : null,
       qc: row[7],
-      pauseStart: (function() {
-        var meta = parseLogMeta(row.length > 12 ? row[12] : "");
-        var openStart = getOpenPauseStart(meta);
-        if (openStart) return new Date(openStart).getTime();
-        return row[9] ? new Date(row[9]).getTime() : null;
-      })(),
-      pausedMins: (function() {
-        var meta = parseLogMeta(row.length > 12 ? row[12] : "");
-        var closed = cumulativePauseMinsFromMeta(meta, row[4]);
-        if (closed) return closed;
-        return parseFloat(row[10]) || 0;
-      })(),
-      pauseIntervals: getPauseIntervalsForRow(row),
-      batchId: parseLogMeta(row.length > 12 ? row[12] : "").batchId || "",
-      batchShare: parseLogMeta(row.length > 12 ? row[12] : "").batchShare || 1,
-      batchSplitAt: parseLogMeta(row.length > 12 ? row[12] : "").batchSplitAt || null,
-      entryType: parseLogMeta(row.length > 12 ? row[12] : "").entryType || "production",
+      pauseStart: openStart ? new Date(openStart).getTime() : (row[9] ? new Date(row[9]).getTime() : null),
+      pausedMins: cumulativePauseMinsFromMeta(meta, row[4]) || parseFloat(row[10]) || 0,
+      pauseIntervals: (meta.pauses && meta.pauses.length) ? meta.pauses : getPauseIntervalsForRow(row),
+      batchId: meta.batchId || "",
+      batchShare: meta.batchShare || 1,
+      batchSplitAt: meta.batchSplitAt || null,
+      entryType: meta.entryType || "production",
       durationMins: calculateWorkMinutesFromLog(row),
       week: weekStr
     };
   });
 
-  // 2. Get Orders (AND FILTER THEM)
-  var orderSheet = getSheetOrDie(ss, TAB_ORDERS);
-  var orderData = orderSheet.getDataRange().getValues();
+  var orderData = getSheetGrid(ss, TAB_ORDERS, 3).slice();
   orderData.shift(); 
   
   var orders = [];
@@ -1420,7 +1459,7 @@ function getNextStatus(current) {
  * IT IGNORES PLATE CUTTING so parallel work can happen.
  */
 function getActiveAssignments(ss) {
-  return getActiveAssignmentsFromData(getSheetGrid(ss, TAB_LOGS, 13));
+  return getActiveAssignmentsFromData(getLogPack(ss).values);
 }
 
 function getActiveAssignmentsFromData(logData) {
@@ -1924,15 +1963,17 @@ function workerPauseOrder(rowIndex, orderNum, workerName, reason) {
   try {
     var ss = getSpreadsheet();
     var logSheet = getSheetOrDie(ss, TAB_LOGS);
-    var logs = logSheet.getDataRange().getValues();
+    var pack = getLogPack(ss);
+    var logs = pack.values;
     var pausedSomething = false;
     for (var i = logs.length - 1; i >= 1; i--) {
       if (String(logs[i][1]) === String(orderNum) && String(logs[i][2]).trim() === String(workerName).trim() && !logs[i][6]) {
          var meta = parseLogMeta(logs[i].length > 12 ? logs[i][12] : "");
          if (!hasOpenPause(meta.pauses) && !logs[i][9]) {
+            var sheetRow = packSheetRow(pack, i);
             meta = addPauseToMeta(meta, reason);
-            writeLogMeta(logSheet, i + 1, meta);
-            syncLegacyPauseCells(logSheet, i + 1, meta, logs[i][4]);
+            writeLogMeta(logSheet, sheetRow, meta);
+            syncLegacyPauseCells(logSheet, sheetRow, meta, logs[i][4]);
             pausedSomething = true;
          }
       }
@@ -1969,15 +2010,17 @@ function adminPauseOrder(orderNum) {
   try {
     var ss = getSpreadsheet();
     var logSheet = getSheetOrDie(ss, TAB_LOGS);
-    var logs = logSheet.getDataRange().getValues();
+    var pack = getLogPack(ss);
+    var logs = pack.values;
     var pausedSomething = false;
     for (var i = logs.length - 1; i >= 1; i--) {
       if (String(logs[i][1]) === String(orderNum) && !logs[i][6]) {
          var meta = parseLogMeta(logs[i].length > 12 ? logs[i][12] : "");
          if (!hasOpenPause(meta.pauses) && !logs[i][9]) {
+            var sheetRow = packSheetRow(pack, i);
             meta = addPauseToMeta(meta, "Admin pause");
-            writeLogMeta(logSheet, i + 1, meta);
-            syncLegacyPauseCells(logSheet, i + 1, meta, logs[i][4]);
+            writeLogMeta(logSheet, sheetRow, meta);
+            syncLegacyPauseCells(logSheet, sheetRow, meta, logs[i][4]);
             pausedSomething = true;
          }
       }
@@ -1997,15 +2040,17 @@ function adminResumeOrder(orderNum) {
   try {
     var ss = getSpreadsheet();
     var logSheet = getSheetOrDie(ss, TAB_LOGS);
-    var logs = logSheet.getDataRange().getValues();
+    var pack = getLogPack(ss);
+    var logs = pack.values;
     var resumedSomething = false;
     for (var i = logs.length - 1; i >= 1; i--) {
       if (String(logs[i][1]) === String(orderNum) && !logs[i][6]) {
          var meta = parseLogMeta(logs[i].length > 12 ? logs[i][12] : "");
          if (hasOpenPause(meta.pauses) || logs[i][9]) {
+            var sheetRow = packSheetRow(pack, i);
             meta = closeOpenPauseInMeta(meta, new Date());
-            writeLogMeta(logSheet, i + 1, meta);
-            syncLegacyPauseCells(logSheet, i + 1, meta, logs[i][4]);
+            writeLogMeta(logSheet, sheetRow, meta);
+            syncLegacyPauseCells(logSheet, sheetRow, meta, logs[i][4]);
             resumedSomething = true;
          }
       }
@@ -2427,59 +2472,63 @@ function findOrderRowByNumber(orderSheet, orderNum) {
   return -1;
 }
 
-function findOpenLogRow(logs, logId, orderNum, workerName) {
-  var rowToUpdate = -1;
+function findOpenLogRow(pack, logId, orderNum, workerName) {
+  var logs = pack.values;
+  var valuesIndex = -1;
   if (logId) {
     var normalizedLogId = String(logId).trim();
     for (var i = 1; i < logs.length; i++) {
       if (String(logs[i][0]).trim() === normalizedLogId) {
-        rowToUpdate = i + 1;
+        valuesIndex = i;
         break;
       }
     }
   }
-  if (rowToUpdate !== -1) {
-    var r = logs[rowToUpdate - 1];
+  if (valuesIndex !== -1) {
+    var r = logs[valuesIndex];
     var matchesOrder = !orderNum || String(r[1]) === String(orderNum);
     var matchesWorker = !workerName || String(r[2]).trim() === String(workerName).trim();
     var isOpen = !r[6];
-    if (!matchesOrder || !matchesWorker || !isOpen) rowToUpdate = -1;
+    if (!matchesOrder || !matchesWorker || !isOpen) valuesIndex = -1;
   }
-  if (rowToUpdate === -1 && orderNum && workerName) {
+  if (valuesIndex === -1 && orderNum && workerName) {
     for (var j = logs.length - 1; j >= 1; j--) {
       if (String(logs[j][1]) === String(orderNum) &&
           String(logs[j][2]).trim() === String(workerName).trim() &&
           !logs[j][6]) {
-        rowToUpdate = j + 1;
+        valuesIndex = j;
         break;
       }
     }
   }
-  return rowToUpdate;
+  return valuesIndex === -1 ? -1 : packSheetRow(pack, valuesIndex);
 }
 
-function closeIndirectTasksForWorker(ss, workerName) {
+function closeIndirectTasksForWorker(ss, workerName, pack) {
+  pack = pack || getLogPack(ss);
   var logSheet = getSheetOrDie(ss, TAB_LOGS);
-  var logs = logSheet.getDataRange().getValues();
+  var logs = pack.values;
   var closed = 0;
   var now = new Date();
   for (var i = 1; i < logs.length; i++) {
     var meta = parseLogMeta(logs[i].length > 12 ? logs[i][12] : "");
     var isIndirect = meta.entryType === "indirect" || String(logs[i][3]).trim() === "Indirect";
     if (isIndirect && String(logs[i][2]).trim() === String(workerName).trim() && !logs[i][6]) {
+      var sheetRow = packSheetRow(pack, i);
       meta = closeOpenPauseInMeta(meta, now);
-      logSheet.getRange(i + 1, 7).setValue(now);
-      writeLogMeta(logSheet, i + 1, meta);
-      syncLegacyPauseCells(logSheet, i + 1, meta, logs[i][4]);
+      logSheet.getRange(sheetRow, 7).setValue(now);
+      writeLogMeta(logSheet, sheetRow, meta);
+      syncLegacyPauseCells(logSheet, sheetRow, meta, logs[i][4]);
       closed++;
     }
   }
   return closed;
 }
 
-function autoPauseWorkerOtherJobs(ss, workerName, exceptOrders, reason, exceptBatchId) {
+function autoPauseWorkerOtherJobs(ss, workerName, exceptOrders, reason, exceptBatchId, pack) {
+  pack = pack || getLogPack(ss);
   var logSheet = getSheetOrDie(ss, TAB_LOGS);
-  var logs = logSheet.getDataRange().getValues();
+  var logs = pack.values;
   var exceptMap = {};
   (exceptOrders || []).forEach(function(o) { exceptMap[String(o)] = true; });
   var paused = [];
@@ -2491,25 +2540,28 @@ function autoPauseWorkerOtherJobs(ss, workerName, exceptOrders, reason, exceptBa
     if (exceptMap[String(logs[i][1])]) continue;
     if (exceptBatchId && meta.batchId && meta.batchId === exceptBatchId) continue;
     if (hasOpenPause(meta.pauses) || logs[i][9]) continue;
+    var sheetRow = packSheetRow(pack, i);
     meta = addPauseToMeta(meta, reason || "Switched job");
-    writeLogMeta(logSheet, i + 1, meta);
-    syncLegacyPauseCells(logSheet, i + 1, meta, logs[i][4]);
+    writeLogMeta(logSheet, sheetRow, meta);
+    syncLegacyPauseCells(logSheet, sheetRow, meta, logs[i][4]);
     paused.push(String(logs[i][1]));
   }
   return paused;
 }
 
-function resumeWorkerLog(ss, workerName, orderNum) {
+function resumeWorkerLog(ss, workerName, orderNum, pack) {
+  pack = pack || getLogPack(ss);
   var logSheet = getSheetOrDie(ss, TAB_LOGS);
-  var logs = logSheet.getDataRange().getValues();
+  var logs = pack.values;
   for (var i = logs.length - 1; i >= 1; i--) {
     if (String(logs[i][1]) === String(orderNum) &&
         String(logs[i][2]).trim() === String(workerName).trim() &&
         !logs[i][6]) {
+      var sheetRow = packSheetRow(pack, i);
       var meta = parseLogMeta(logs[i].length > 12 ? logs[i][12] : "");
       meta = closeOpenPauseInMeta(meta, new Date());
-      writeLogMeta(logSheet, i + 1, meta);
-      syncLegacyPauseCells(logSheet, i + 1, meta, logs[i][4]);
+      writeLogMeta(logSheet, sheetRow, meta);
+      syncLegacyPauseCells(logSheet, sheetRow, meta, logs[i][4]);
       return true;
     }
   }
@@ -2517,8 +2569,8 @@ function resumeWorkerLog(ss, workerName, orderNum) {
 }
 
 function autoSwitchWeldersAfterPlate(ss, orderNum) {
-  var logSheet = getSheetOrDie(ss, TAB_LOGS);
-  var logs = logSheet.getDataRange().getValues();
+  var pack = getLogPack(ss);
+  var logs = pack.values;
   var switched = [];
   for (var i = 1; i < logs.length; i++) {
     var role = String(logs[i][3]).trim();
@@ -2530,9 +2582,9 @@ function autoSwitchWeldersAfterPlate(ss, orderNum) {
     var isPaused = hasOpenPause(meta.pauses) || !!logs[i][9];
     if (!isPaused) continue;
 
-    var pausedOthers = autoPauseWorkerOtherJobs(ss, worker, [orderNum], "Plate ready on " + orderNum, meta.batchId);
-    closeIndirectTasksForWorker(ss, worker);
-    resumeWorkerLog(ss, worker, orderNum);
+    var pausedOthers = autoPauseWorkerOtherJobs(ss, worker, [orderNum], "Plate ready on " + orderNum, meta.batchId, pack);
+    closeIndirectTasksForWorker(ss, worker, pack);
+    resumeWorkerLog(ss, worker, orderNum, pack);
     var notice = {
       type: "plate-ready",
       worker: worker,
@@ -2578,7 +2630,8 @@ function undoAutoSwitch(workerName) {
 function leaveBatchForOrder(workerName, keepOrder) {
   var ss = getSpreadsheet();
   var logSheet = getSheetOrDie(ss, TAB_LOGS);
-  var logs = logSheet.getDataRange().getValues();
+  var pack = getLogPack(ss);
+  var logs = pack.values;
   var now = new Date();
   var batchId = "";
   for (var i = logs.length - 1; i >= 1; i--) {
@@ -2599,8 +2652,9 @@ function leaveBatchForOrder(workerName, keepOrder) {
     if (String(logs[j][1]) !== String(keepOrder)) {
       m = addPauseToMeta(m, "Batch cut done — assembling " + keepOrder);
     }
-    writeLogMeta(logSheet, j + 1, m);
-    syncLegacyPauseCells(logSheet, j + 1, m, logs[j][4]);
+    var sheetRow = packSheetRow(pack, j);
+    writeLogMeta(logSheet, sheetRow, m);
+    syncLegacyPauseCells(logSheet, sheetRow, m, logs[j][4]);
   }
   bumpFloorCache();
   return { success: true };
@@ -2681,8 +2735,7 @@ function alreadyAlertedToday(idleSheet, workerName) {
 function checkIdleWorkers() {
   if (!isWithinShiftNow()) return;
   var ss = getSpreadsheet();
-  var logSheet = getSheetOrDie(ss, TAB_LOGS);
-  var logs = logSheet.getDataRange().getValues();
+  var logs = getLogPack(ss).values;
   var users = getUsersAndRoles();
   var idleSheet = getIdleAlertSheet(ss);
   var now = new Date();
@@ -2768,7 +2821,7 @@ function assignIndirectTask(workerName, taskName, assignedBy) {
   if (!workerName || !taskName) return { success: false, message: "Worker and task are required." };
   var ss = getSpreadsheet();
   var logSheet = getSheetOrDie(ss, TAB_LOGS);
-  var logs = logSheet.getDataRange().getValues();
+  var logs = getLogPack(ss).values;
   if (workerHasRunningJob(logs, workerName)) {
     return { success: false, message: workerName + " already has a running job." };
   }

--- a/studio-delta-production/Code.gs
+++ b/studio-delta-production/Code.gs
@@ -20,7 +20,12 @@ var QUEUE_FOLDER_ID = "1MRl3nX7-4d8dmrjQU0UrCbzCf6Ilymub";
 var TAB_IDLE = "Idle_Alerts";
 var TZ_JOBURG = "Africa/Johannesburg";
 var SAST_OFFSET_MS = 2 * 60 * 60 * 1000; // South Africa has no DST
-var STANDARD_DAY_MINS = 8 * 60;
+var STANDARD_DAY_MINS = 7 * 60 + 30; // paid shift: 07:45-15:45 minus 30 min lunch
+var SHIFT_START_MINS = 7 * 60 + 45;
+var SHIFT_END_MINS = 15 * 60 + 45;
+var LUNCH_START_MINS = 12 * 60;
+var LUNCH_END_MINS = 12 * 60 + 30;
+var SHIFT_DURATION = STANDARD_DAY_MINS;
 var IDLE_GRACE_MINS = 10;
 var INDIRECT_TASKS = ["Cleaning", "Maintenance", "Material handling", "Waiting for materials", "Waiting for plate", "Meeting", "Training", "Other"];
 
@@ -1303,12 +1308,6 @@ function calcRawServerMins(start, end, taskName) {
     return (end.getTime() - start.getTime()) / 1000 / 60;
   }
 
-  var SHIFT_START_MINS = 7 * 60 + 30;
-  var LUNCH_START_MINS = 12 * 60;
-  var LUNCH_END_MINS   = 13 * 60;
-  var SHIFT_END_MINS   = 15 * 60 + 45;
-  var SHIFT_DURATION   = 435;
-
   function getWorkingMins(startDate, endDate) {
      var sMins = sastMinsOfDay(startDate);
      var eMins = sastMinsOfDay(endDate);
@@ -1348,7 +1347,7 @@ function calcRawServerMins(start, end, taskName) {
 
     var endDow = sastDayOfWeek(end);
     if (endDow !== 0 && endDow !== 6) {
-      totalMinutes += getWorkingMins(sastWallToDate(end, 7, 30), end);
+      totalMinutes += getWorkingMins(sastWallToDate(end, Math.floor(SHIFT_START_MINS / 60), SHIFT_START_MINS % 60), end);
     }
   }
 
@@ -2324,7 +2323,7 @@ function isWithinShiftNow() {
   var dow = sastDayOfWeek(now);
   if (dow === 0 || dow === 6) return false;
   var mins = sastMinsOfDay(now);
-  return mins >= (7 * 60 + 30) && mins <= (15 * 60 + 45);
+  return mins >= SHIFT_START_MINS && mins < SHIFT_END_MINS;
 }
 
 function getPauseIntervalsForRow(row) {
@@ -2394,6 +2393,62 @@ function calculateWorkMinutesFromLog(row) {
     meta.pauses = getPauseIntervalsForRow(row);
   }
   return calculateWorkMinutesMeta(start, end, task, meta, row[10]);
+}
+
+function splitWorkByDay(row) {
+  var start = row[5] ? new Date(row[5]) : null;
+  if (start && isNaN(start.getTime())) start = null;
+  if (!start) return [];
+  var isOpen = !row[6];
+  var end = row[6] ? new Date(row[6]) : new Date();
+  if (end && isNaN(end.getTime())) end = new Date();
+  if (end.getTime() <= start.getTime()) return [];
+  var task = row[4];
+  var meta = parseLogMeta(row.length > 12 ? row[12] : "");
+  if (row[9] && !hasOpenPause(meta.pauses)) {
+    meta.pauses = getPauseIntervalsForRow(row);
+  }
+  var hasPauseTimes = meta.pauses && meta.pauses.length > 0;
+  var fullRaw = 0;
+  if (!hasPauseTimes && row[10]) {
+    fullRaw = calcRawServerMins(start, end, task);
+  }
+  var slices = [];
+  var endStamp = sastDayStamp(end);
+  var cursor = sastWallToDate(start, 0, 0);
+  var safety = 0;
+  while (sastDayStamp(cursor) <= endStamp && safety < 400) {
+    safety++;
+    var dayStamp = sastDayStamp(cursor);
+    var dayStart = sastWallToDate(cursor, 0, 0);
+    var nextMidnight = addSastDays(dayStart, 1);
+    var sliceStartMs = Math.max(start.getTime(), dayStart.getTime());
+    var sliceEndMs = Math.min(end.getTime(), nextMidnight.getTime());
+    if (sliceEndMs > sliceStartMs) {
+      var sliceStart = new Date(sliceStartMs);
+      var sliceEnd = new Date(sliceEndMs);
+      var mins = 0;
+      if (hasPauseTimes) {
+        mins = calculateWorkMinutesMeta(sliceStart, sliceEnd, task, meta, 0);
+      } else if (row[10] && fullRaw > 0) {
+        var sliceRaw = calcRawServerMins(sliceStart, sliceEnd, task);
+        mins = Math.max(0, sliceRaw - (parseFloat(row[10]) || 0) * (sliceRaw / fullRaw));
+      } else {
+        mins = calculateWorkMinutesMeta(sliceStart, sliceEnd, task, meta, 0);
+      }
+      if (mins > 0) {
+        var stillRunning = isOpen && dayStamp === sastDayStamp(end);
+        slices.push({
+          dayStamp: dayStamp,
+          start: sliceStart,
+          end: stillRunning ? null : sliceEnd,
+          mins: mins
+        });
+      }
+    }
+    cursor = addSastDays(cursor, 1);
+  }
+  return slices;
 }
 
 function hasOpenPause(pauses) {
@@ -2877,36 +2932,56 @@ function getActivityReport(period, refDateMs, workerFilter) {
     return Utilities.formatDate(dateObj, TZ_JOBURG, "yyyy-MM") === refMonth;
   }
 
+  function inRangeStamp(stamp) {
+    if (!stamp) return false;
+    if (period === "day") return stamp === refStamp;
+    if (period === "month") return String(stamp).slice(0, 7) === refMonth;
+    var parts = String(stamp).split("-");
+    if (parts.length < 3) return false;
+    var noon = sastWallToDate(new Date(Date.UTC(Number(parts[0]), Number(parts[1]) - 1, Number(parts[2]), 10, 0, 0)), 12, 0);
+    return inRange(noon);
+  }
+
   var byWorker = {};
   var allWorkerNames = {};
   for (var i = 1; i < logData.length; i++) {
     var worker = String(logData[i][2] || "").trim();
     if (!worker) continue;
     var start = logData[i][5] ? new Date(logData[i][5]) : null;
-    var end = logData[i][6] ? new Date(logData[i][6]) : new Date();
-    var anchor = logData[i][6] ? new Date(logData[i][6]) : start;
-    if (!anchor || isNaN(anchor) || !inRange(anchor)) continue;
+    if (!start || isNaN(start.getTime())) continue;
+
+    var slices = splitWorkByDay(logData[i]);
+    var anyInRange = false;
+    for (var s = 0; s < slices.length; s++) {
+      if (inRangeStamp(slices[s].dayStamp)) { anyInRange = true; break; }
+    }
+    if (!anyInRange) continue;
     allWorkerNames[worker] = true;
     if (workerFilter && String(workerFilter).trim() && String(workerFilter).trim().toLowerCase() !== worker.toLowerCase()) continue;
 
-    var mins = calculateWorkMinutesFromLog(logData[i]);
-    var dayStamp = sastDayStamp(anchor);
+    var rowMeta = parseLogMeta(logData[i].length > 12 ? logData[i][12] : "");
     if (!byWorker[worker]) byWorker[worker] = { worker: worker, days: {}, tasks: [] };
-    if (!byWorker[worker].days[dayStamp]) {
-      byWorker[worker].days[dayStamp] = { date: dayStamp, minutes: 0, overtime: 0, regular: 0, tasks: [] };
+    for (var s = 0; s < slices.length; s++) {
+      var slice = slices[s];
+      if (!inRangeStamp(slice.dayStamp)) continue;
+      var dayStamp = slice.dayStamp;
+      if (!byWorker[worker].days[dayStamp]) {
+        byWorker[worker].days[dayStamp] = { date: dayStamp, minutes: 0, overtime: 0, regular: 0, tasks: [] };
+      }
+      var task = {
+        order: logData[i][1],
+        role: logData[i][3],
+        task: logData[i][4],
+        start: slice.start ? slice.start.getTime() : null,
+        end: slice.end ? slice.end.getTime() : null,
+        minutes: slice.mins,
+        date: dayStamp,
+        entryType: rowMeta.entryType || "production"
+      };
+      byWorker[worker].days[dayStamp].minutes += slice.mins;
+      byWorker[worker].days[dayStamp].tasks.push(task);
+      byWorker[worker].tasks.push(task);
     }
-    var task = {
-      order: logData[i][1],
-      role: logData[i][3],
-      task: logData[i][4],
-      start: start ? start.getTime() : null,
-      end: logData[i][6] ? new Date(logData[i][6]).getTime() : null,
-      minutes: mins,
-      entryType: parseLogMeta(logData[i].length > 12 ? logData[i][12] : "").entryType || "production"
-    };
-    byWorker[worker].days[dayStamp].minutes += mins;
-    byWorker[worker].days[dayStamp].tasks.push(task);
-    byWorker[worker].tasks.push(task);
   }
 
   var workers = [];

--- a/studio-delta-production/Code.gs
+++ b/studio-delta-production/Code.gs
@@ -7,6 +7,8 @@ var TAB_RATES = "Rates";
 var FOLDER_NAME = "Studio_Delta_QC_Records";
 var TAB_STEEL_PROFILES = "Steel_Profiles";
 var TAB_STEEL_USAGE = "Steel_Usage";
+var TAB_BACKBOARDS = "Backboards";
+var TAB_BACKBOARD_USAGE = "Backboard_Usage";
 
 var TEMP_ID_PRE_POWDER = "18gdKTtaJFqG7EALy-OofLoBxcJ873U4sUTUks3_2oEo";
 var TEMP_ID_FINISHED   = "1WXW4F_PIjcA5v2ZSqJDptQrKtlikiVuqOeUy706rV7I";
@@ -196,6 +198,87 @@ function getSteelProfiles() {
   return profiles;
 }
 
+function getBackboards() {
+  var ss = getSpreadsheet();
+  var sheet = ss.getSheetByName(TAB_BACKBOARDS);
+
+  if (!sheet) {
+    sheet = ss.insertSheet(TAB_BACKBOARDS);
+    sheet.hideSheet();
+    sheet.appendRow(["Category", "Profile Name"]);
+    return [];
+  }
+
+  var cached = floorCacheGet("backboards");
+  if (cached) return cached;
+
+  var data = sheet.getDataRange().getValues();
+  if (data.length <= 1) {
+    return [];
+  }
+
+  var profiles = [];
+  for (var i = 1; i < data.length; i++) {
+    var cat = String(data[i][0]).trim();
+    var name = String(data[i][1]).trim();
+    if (!name && cat) {
+      name = cat;
+      cat = "Uncategorized";
+    }
+    if (name) profiles.push({ category: cat, name: name });
+  }
+  floorCachePut("backboards", profiles, CACHE_TTL_BACKBOARD);
+  return profiles;
+}
+
+function processNeedsBackboard(role, processName) {
+  var r = String(role || "").trim().toLowerCase();
+  var p = String(processName || "").trim().toLowerCase();
+  return r === "assembly" || p === "assembly" || p === "final qc";
+}
+
+function writeBackboardUsage(ss, orderNum, workerName, processName, backboardUsageData) {
+  if (!backboardUsageData || backboardUsageData.length === 0) return;
+  var usageSheet = ss.getSheetByName(TAB_BACKBOARD_USAGE);
+  if (!usageSheet) {
+    usageSheet = ss.insertSheet(TAB_BACKBOARD_USAGE);
+    usageSheet.hideSheet();
+    usageSheet.appendRow(["Timestamp", "Order #", "Worker", "Process", "Type", "Size"]);
+  }
+
+  var profilesSheet = ss.getSheetByName(TAB_BACKBOARDS);
+  if (!profilesSheet) {
+    getBackboards();
+    profilesSheet = ss.getSheetByName(TAB_BACKBOARDS);
+  }
+  var existingProfileData = profilesSheet ? profilesSheet.getDataRange().getValues() : [];
+  var existingProfileNames = [];
+  for (var p = 1; p < existingProfileData.length; p++) {
+    var pv = String(existingProfileData[p][1] || existingProfileData[p][0]).trim().toLowerCase();
+    if (pv) existingProfileNames.push(pv);
+  }
+
+  backboardUsageData.forEach(function(item) {
+    var usageName = item.category && item.category !== "Uncategorized" ? (item.category + " - " + item.type) : item.type;
+    usageSheet.appendRow([
+      new Date(),
+      orderNum,
+      workerName,
+      processName,
+      usageName,
+      item.size
+    ]);
+
+    if (item.isCustom && profilesSheet) {
+      var newProfileLower = String(item.type).trim().toLowerCase();
+      if (newProfileLower && existingProfileNames.indexOf(newProfileLower) === -1) {
+        profilesSheet.appendRow([item.category || "Custom", String(item.type).trim()]);
+        existingProfileNames.push(newProfileLower);
+      }
+    }
+  });
+}
+
 function doGet() {
   return HtmlService.createTemplateFromFile('index')
     .evaluate()
@@ -243,6 +326,7 @@ function getSheetGrid(ss, tabName, numCols) {
 var CACHE_TTL_FLOOR = 20;
 var CACHE_TTL_USERS = 45;
 var CACHE_TTL_STEEL = 300;
+var CACHE_TTL_BACKBOARD = 300;
 var CACHE_TTL_ADMIN = 25;
 
 function floorCacheGen() {
@@ -664,7 +748,7 @@ function startOrder(rowIndex, workerName, role, batchRowIndices) {
 }
 
 // STEP 2: Added steelUsageData as the 7th parameter. orderNumHint is 8th (optional).
-function finishOrder(rowIndex, logId, qcData, signatureUrl, filesData, workerName, steelUsageData, orderNumHint) {
+function finishOrder(rowIndex, logId, qcData, signatureUrl, filesData, workerName, steelUsageData, orderNumHint, backboardUsageData) {
   var lock = LockService.getScriptLock();
   lock.waitLock(120000); 
   
@@ -707,6 +791,11 @@ function finishOrder(rowIndex, logId, qcData, signatureUrl, filesData, workerNam
     if (role === 'Profile Cutting' || role === 'Plate Cutting') {
       if (!steelUsageData || steelUsageData.length === 0) {
         throw new Error("Server rejected: Steel material usage must be logged before finishing " + role + ".");
+      }
+    }
+    if (processNeedsBackboard(role, processName)) {
+      if (!backboardUsageData || backboardUsageData.length === 0) {
+        throw new Error("Server rejected: Backboard used must be logged before finishing " + (processName || role) + ".");
       }
     }
 
@@ -763,6 +852,8 @@ function finishOrder(rowIndex, logId, qcData, signatureUrl, filesData, workerNam
         }
       });
     }
+
+    writeBackboardUsage(ss, orderNum, workerName, processName, backboardUsageData);
 
     var resultStr = qcData ? qcData.map(function(i){return i.q+": "+i.a}).join("\n") : "Complete";
     logSheet.getRange(rowToUpdate, 7).setValue(endTime);
@@ -2619,20 +2710,6 @@ function checkIdleWorkers() {
     ]);
     alerted.push(name + " (" + role + ")");
   }
-
-  if (alerted.length > 0 && ALERT_EMAIL_RECIPIENT) {
-    try {
-      MailApp.sendEmail({
-        to: ALERT_EMAIL_RECIPIENT,
-        subject: "Idle workers need a task assigned (" + alerted.length + ")",
-        htmlBody: "<p>The following workers have no running job during shift hours:</p><ul><li>" +
-                  alerted.join("</li><li>") +
-                  "</li></ul><p>Open Studio Delta Production → Activity / Idle workers and assign a non-order task.</p>"
-      });
-    } catch (e) {
-      Logger.log("Idle email failed: " + e);
-    }
-  }
 }
 
 function getIdleWorkers() {
@@ -2653,6 +2730,38 @@ function getIdleWorkers() {
     }
   }
   return { workers: list, tasks: INDIRECT_TASKS };
+}
+
+function heartbeatKey(name) {
+  return "hb_" + String(name || "").trim().toLowerCase();
+}
+
+function userSeesIdleAlerts(workerName) {
+  var profile = getUserProfileByName(workerName);
+  if (!profile) return false;
+  if (profile.isAdmin || profile.isQcOnly) return true;
+  if (profile.tasks && profile.tasks.indexOf("Quality Control") !== -1) return true;
+  var role = String(profile.role || "").toLowerCase();
+  return role === "qc" || role === "quality control";
+}
+
+function markStaffHeartbeat(workerName) {
+  if (!workerName || !userSeesIdleAlerts(workerName)) return;
+  try {
+    var cache = CacheService.getScriptCache();
+    cache.put(heartbeatKey(workerName), JSON.stringify({ name: workerName, t: new Date().getTime() }), 120);
+  } catch (e) {}
+}
+
+function pollIdleAlerts(workerName) {
+  lazySetup();
+  if (!workerName) return { ok: false, alerts: [], canAssign: false, tasks: INDIRECT_TASKS };
+  markStaffHeartbeat(workerName);
+  if (!userSeesIdleAlerts(workerName)) {
+    return { ok: true, alerts: [], canAssign: false, tasks: INDIRECT_TASKS };
+  }
+  var data = getIdleWorkers();
+  return { ok: true, alerts: data.workers || [], canAssign: true, tasks: data.tasks || INDIRECT_TASKS };
 }
 
 function assignIndirectTask(workerName, taskName, assignedBy) {

--- a/studio-delta-production/Code.gs
+++ b/studio-delta-production/Code.gs
@@ -48,6 +48,9 @@ var TASK_ALIAS_MAP = {
 };
 
 function ensureUsersSheetTasksColumn() {
+  try {
+    if (CacheService.getScriptCache().get("usersTasksCol")) return;
+  } catch (e) {}
   var ss = getSpreadsheet();
   var sheet = getSheetOrDie(ss, TAB_USERS);
   var lastCol = Math.max(sheet.getLastColumn(), 1);
@@ -62,6 +65,7 @@ function ensureUsersSheetTasksColumn() {
   if (!found) {
     sheet.getRange(1, 4).setValue("Tasks");
   }
+  try { CacheService.getScriptCache().put("usersTasksCol", "1", 21600); } catch (e) {}
 }
 
 function canonicalTaskName(raw) {
@@ -131,15 +135,11 @@ function readUserRowProfile(row) {
 }
 
 function getUserProfileByName(workerName) {
-  var ss = getSpreadsheet();
-  var sheet = getSheetOrDie(ss, TAB_USERS);
-  var data = sheet.getDataRange().getValues();
   var needle = String(workerName || "").trim().toLowerCase();
   if (!needle) return null;
-  for (var i = 1; i < data.length; i++) {
-    if (String(data[i][0] || "").trim().toLowerCase() === needle) {
-      return readUserRowProfile(data[i]);
-    }
+  var users = getUsersAndRoles();
+  for (var i = 0; i < users.length; i++) {
+    if (String(users[i].name || "").trim().toLowerCase() === needle) return users[i];
   }
   return null;
 }
@@ -170,6 +170,9 @@ function getSteelProfiles() {
     return[];
   }
 
+  var cachedSteel = floorCacheGet("steel");
+  if (cachedSteel) return cachedSteel;
+
   // Read existing profiles
   var data = sheet.getDataRange().getValues();
   if (data.length <= 1) {
@@ -189,12 +192,11 @@ function getSteelProfiles() {
     }
     if (name) profiles.push({ category: cat, name: name });
   }
+  floorCachePut("steel", profiles, CACHE_TTL_STEEL);
   return profiles;
 }
 
 function doGet() {
-  try { ensureIdleTrigger(); } catch (e) {}
-  try { ensureUsersSheetTasksColumn(); } catch (e) {}
   return HtmlService.createTemplateFromFile('index')
     .evaluate()
     .setTitle('Studio Delta Production')
@@ -202,54 +204,106 @@ function doGet() {
     .addMetaTag('viewport', 'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0'); 
 }
 
+function lazySetup() {
+  try { ensureIdleTrigger(); } catch (e) {}
+  try { ensureUsersSheetTasksColumn(); } catch (e) {}
+}
+
+var _ssMemo = null;
+var _sheetMemo = {};
+
 function getSpreadsheet() {
+  if (_ssMemo) return _ssMemo;
   if (SHEET_ID && SHEET_ID !== "1pdvAFTIyd5sf8Wbf38MSd4cfk3mb3McPqJrYeM8SOYk") {
-    return SpreadsheetApp.openById(SHEET_ID);
+    _ssMemo = SpreadsheetApp.openById(SHEET_ID);
+  } else {
+    _ssMemo = SpreadsheetApp.getActiveSpreadsheet();
   }
-  
-  return SpreadsheetApp.getActiveSpreadsheet();
+  return _ssMemo;
 }
 
 function getSheetOrDie(ss, tabName) {
+  if (_sheetMemo[tabName]) return _sheetMemo[tabName];
   var sheet = ss.getSheetByName(tabName);
   if (!sheet) throw new Error("Missing Tab: '" + tabName + "'. Please create it.");
+  _sheetMemo[tabName] = sheet;
   return sheet;
 }
 
-function getPlateCuttingStatus(ss, orderNum) {
-  var logSheet = getSheetOrDie(ss, TAB_LOGS);
-  var logData = logSheet.getDataRange().getValues();
-  
-  // Loop backwards to find the most recent entry
-  for (var i = logData.length - 1; i >= 1; i--) { 
-    var logOrderNum = logData[i][1]; 
-    var logRole = logData[i][3]; 
-    var logWorker = logData[i][2]; 
-    var logEndTime = logData[i][6]; 
-    var meta = parseLogMeta(logData[i].length > 12 ? logData[i][12] : "");
-    var pauseStart = getOpenPauseStart(meta) || logData[i][9];
-    var pauseReason = "";
-    if (meta.pauses && meta.pauses.length) pauseReason = meta.pauses[meta.pauses.length - 1].reason || "";
-    if (!pauseReason) pauseReason = logData[i].length > 11 ? logData[i][11] : "";
+function getSheetGrid(ss, tabName, numCols) {
+  var sheet = getSheetOrDie(ss, tabName);
+  var lastRow = sheet.getLastRow();
+  if (lastRow < 1) return [];
+  var lastCol = sheet.getLastColumn();
+  if (lastCol < 1) return [];
+  var cols = numCols ? Math.min(numCols, lastCol) : lastCol;
+  return sheet.getRange(1, 1, lastRow, cols).getValues();
+}
 
-    if (String(logOrderNum) == String(orderNum) && String(logRole).trim() === 'Plate Cutting') {
-      if (!logEndTime) {
-        return {
-          status: 'Plate Cutting',
-          assigned: logWorker,
-          isPaused: !!pauseStart,
-          pauseReason: pauseReason || "",
-          logId: logData[i][0],
-          batchId: meta.batchId || "",
-          isBatched: !!(meta.batchId && !meta.batchSplitAt && (meta.batchShare || 1) > 1)
-        };
-      } else {
-        return {status: 'Finished', assigned: '', isPaused: false, pauseReason: "", logId: "", batchId: "", isBatched: false};
-      }
-    }
+var CACHE_TTL_FLOOR = 20;
+var CACHE_TTL_USERS = 45;
+var CACHE_TTL_STEEL = 300;
+var CACHE_TTL_ADMIN = 25;
+
+function floorCacheGen() {
+  try { return CacheService.getScriptCache().get("floorGen") || "0"; } catch (e) { return "0"; }
+}
+function bumpFloorCache() {
+  try { CacheService.getScriptCache().put("floorGen", String(new Date().getTime()), 21600); } catch (e) {}
+}
+function floorCacheGet(key) {
+  try {
+    var raw = CacheService.getScriptCache().get(floorCacheGen() + ":" + key);
+    return raw ? JSON.parse(raw) : null;
+  } catch (e) { return null; }
+}
+function floorCachePut(key, value, ttl) {
+  try {
+    var s = JSON.stringify(value);
+    if (s.length > 90000) return;
+    CacheService.getScriptCache().put(floorCacheGen() + ":" + key, s, ttl || CACHE_TTL_FLOOR);
+  } catch (e) {}
+}
+
+function emptyPlateStatus() {
+  return {status: '', assigned: '', isPaused: false, pauseReason: "", logId: "", batchId: "", isBatched: false};
+}
+
+function plateStatusFromLogRow(row) {
+  var meta = parseLogMeta(row.length > 12 ? row[12] : "");
+  var pauseStart = getOpenPauseStart(meta) || row[9];
+  var pauseReason = "";
+  if (meta.pauses && meta.pauses.length) pauseReason = meta.pauses[meta.pauses.length - 1].reason || "";
+  if (!pauseReason) pauseReason = row.length > 11 ? row[11] : "";
+  if (!row[6]) {
+    return {
+      status: 'Plate Cutting',
+      assigned: row[2],
+      isPaused: !!pauseStart,
+      pauseReason: pauseReason || "",
+      logId: row[0],
+      batchId: meta.batchId || "",
+      isBatched: !!(meta.batchId && !meta.batchSplitAt && (meta.batchShare || 1) > 1)
+    };
   }
-  
-  return {status: '', assigned: '', isPaused: false, pauseReason: "", logId: "", batchId: "", isBatched: false}; 
+  return {status: 'Finished', assigned: '', isPaused: false, pauseReason: "", logId: "", batchId: "", isBatched: false};
+}
+
+function buildPlateStatusMap(logData) {
+  var map = {};
+  for (var i = logData.length - 1; i >= 1; i--) {
+    if (String(logData[i][3]).trim() !== 'Plate Cutting') continue;
+    var orderNum = String(logData[i][1]);
+    if (map.hasOwnProperty(orderNum)) continue;
+    map[orderNum] = plateStatusFromLogRow(logData[i]);
+  }
+  return map;
+}
+
+function getPlateCuttingStatus(ss, orderNum) {
+  var logData = getSheetGrid(ss, TAB_LOGS, 13);
+  var map = buildPlateStatusMap(logData);
+  return map[String(orderNum)] || emptyPlateStatus();
 }
 
 function setPlateCuttingStatus(ss, orderNum, status, worker) {
@@ -269,22 +323,26 @@ function clearPlateCuttingStatus(ss, orderNum) {
 
 // --- CORE: USERS & LOGIN ---
 function getUsersAndRoles() {
+  var cached = floorCacheGet("users");
+  if (cached) return cached;
+  lazySetup();
   var ss = getSpreadsheet();
-  var sheet = getSheetOrDie(ss, TAB_USERS); 
-  var data = sheet.getDataRange().getValues();
+  var data = getSheetGrid(ss, TAB_USERS, 4);
   if (data.length <= 1) return []; 
-  data.shift(); // Remove header
-  return data.map(function(row) {
-    var profile = readUserRowProfile(row);
-    return {
+  var users = [];
+  for (var i = 1; i < data.length; i++) {
+    var profile = readUserRowProfile(data[i]);
+    users.push({
       name: profile.name,
       role: profile.role,
       jobTitle: profile.jobTitle,
       isAdmin: profile.isAdmin,
       isQcOnly: profile.isQcOnly,
       tasks: profile.tasks
-    };
-  });
+    });
+  }
+  floorCachePut("users", users, CACHE_TTL_USERS);
+  return users;
 }
 
 // Helper function for case-insensitive status comparison
@@ -339,6 +397,7 @@ function verifyLogin(role, name, password) {
 }
 
 function verifyGlobalLogin(name, password) {
+  lazySetup();
   var ss = getSpreadsheet();
   try { ensureUsersSheetTasksColumn(); } catch (e) {}
   var sheet = getSheetOrDie(ss, TAB_USERS);
@@ -384,11 +443,15 @@ function getOrdersForRole(role, workerName) {
   if (workerName && role && role !== "Admin" && !workerCanPerformTask(workerName, role)) {
     return [];
   }
+  lazySetup();
+  var cacheKey = "orders:" + String(role || "");
+  var cached = floorCacheGet(cacheKey);
+  if (cached) return cached;
   var ss = getSpreadsheet();
-  var sheet = getSheetOrDie(ss, TAB_ORDERS);
-  var data = sheet.getDataRange().getValues();
-  
-  var activeAssignments = getActiveAssignments(ss);
+  var data = getSheetGrid(ss, TAB_ORDERS, 7);
+  var logData = getSheetGrid(ss, TAB_LOGS, 13);
+  var activeAssignments = getActiveAssignmentsFromData(logData);
+  var plateMap = (role === 'Plate Cutting') ? buildPlateStatusMap(logData) : {};
   var relevantOrders = [];
   
   var mainVisibilityMap = {
@@ -430,7 +493,7 @@ function getOrdersForRole(role, workerName) {
     var isBatched = assignment ? assignment.isBatched : false;
 
     if (role === 'Plate Cutting') {
-      var plateInfo = getPlateCuttingStatus(ss, orderNum); 
+      var plateInfo = plateMap[String(orderNum)] || emptyPlateStatus();
       var isStageValid = plateCuttingStages.indexOf(mainStatusLower) > -1;
       var isAlreadyActive = plateInfo.status === 'Plate Cutting';
       var isNotFinished = plateInfo.status !== 'Finished';
@@ -471,6 +534,7 @@ function getOrdersForRole(role, workerName) {
       });
     }
   }
+  floorCachePut(cacheKey, relevantOrders, CACHE_TTL_FLOOR);
   return relevantOrders;
 }
 
@@ -595,7 +659,7 @@ function startOrder(rowIndex, workerName, role, batchRowIndices) {
     };
     
   } finally {
-    lock.releaseLock();
+    try { bumpFloorCache(); } catch (ignore2) {} lock.releaseLock();
   }
 }
 
@@ -762,7 +826,7 @@ function finishOrder(rowIndex, logId, qcData, signatureUrl, filesData, workerNam
   } catch(e) {
     return { success: false, error: e.toString() };
   } finally {
-    try { lock.releaseLock(); } catch (ignore) {}
+    try { try { bumpFloorCache(); } catch (ignore2) {} lock.releaseLock(); } catch (ignore) {}
   }
 }
 
@@ -813,7 +877,7 @@ function logWelderSteel(orderNum, workerName, item) {
   } catch(e) {
     return { success: false, error: e.toString() };
   } finally {
-    lock.releaseLock();
+    try { bumpFloorCache(); } catch (ignore2) {} lock.releaseLock();
   }
 }
 
@@ -1155,6 +1219,9 @@ function formatDurationServer(totalMins) {
 
 // --- ADMIN: FETCH ALL DATA ---
 function getAdminDashboardData() {
+  var cached = floorCacheGet("adminDash");
+  if (cached) return cached;
+  lazySetup();
   var ss = getSpreadsheet();
   
   // 1. Get Logs
@@ -1220,7 +1287,9 @@ function getAdminDashboardData() {
     }
   }
 
-  return { logs: logs, orders: orders };
+  var adminPayload = { logs: logs, orders: orders };
+  floorCachePut("adminDash", adminPayload, CACHE_TTL_ADMIN);
+  return adminPayload;
 }
 
 // --- UTILS ---
@@ -1260,35 +1329,31 @@ function getNextStatus(current) {
  * IT IGNORES PLATE CUTTING so parallel work can happen.
  */
 function getActiveAssignments(ss) {
-  var logSheet = getSheetOrDie(ss, TAB_LOGS);
-  var logData = logSheet.getDataRange().getValues();
-  var assignments = {};
+  return getActiveAssignmentsFromData(getSheetGrid(ss, TAB_LOGS, 13));
+}
 
+function getActiveAssignmentsFromData(logData) {
+  var assignments = {};
   for (var i = 1; i < logData.length; i++) {
+    if (logData[i][6]) continue;
     var orderNum = logData[i][1];
-    var worker = logData[i][2];
-    var role = logData[i][3];
-    var endTime = logData[i][6];
+    if (!orderNum) continue;
+    var roleStr = String(logData[i][3]).trim();
+    if (roleStr === 'Plate Cutting' || roleStr === 'Out for Delivery' || roleStr === 'Indirect') continue;
     var meta = parseLogMeta(logData[i].length > 12 ? logData[i][12] : "");
     if (meta.entryType === "indirect") continue;
-
     var pauseStart = getOpenPauseStart(meta) || logData[i][9];
     var pauseReason = "";
     if (meta.pauses && meta.pauses.length) pauseReason = meta.pauses[meta.pauses.length - 1].reason || "";
     if (!pauseReason) pauseReason = logData[i].length > 11 ? logData[i][11] : "";
-
-    var roleStr = String(role).trim();
-
-    if (!endTime && orderNum && roleStr !== 'Plate Cutting' && roleStr !== 'Out for Delivery' && roleStr !== 'Indirect') {
-      assignments[orderNum] = {
-        worker: worker,
-        isPaused: !!pauseStart,
-        pauseReason: pauseReason || "",
-        logId: logData[i][0],
-        batchId: meta.batchId || "",
-        isBatched: !!(meta.batchId && !meta.batchSplitAt && (meta.batchShare || 1) > 1)
-      };
-    }
+    assignments[orderNum] = {
+      worker: logData[i][2],
+      isPaused: !!pauseStart,
+      pauseReason: pauseReason || "",
+      logId: logData[i][0],
+      batchId: meta.batchId || "",
+      isBatched: !!(meta.batchId && !meta.batchSplitAt && (meta.batchShare || 1) > 1)
+    };
   }
   return assignments;
 }
@@ -1786,7 +1851,7 @@ function workerPauseOrder(rowIndex, orderNum, workerName, reason) {
   } catch(e) {
     return {success: false, message: e.toString()};
   } finally {
-    lock.releaseLock();
+    try { bumpFloorCache(); } catch (ignore2) {} lock.releaseLock();
   }
 }
 
@@ -1803,7 +1868,7 @@ function workerResumeOrder(rowIndex, orderNum, workerName) {
   } catch(e) {
     return {success: false, message: e.toString()};
   } finally {
-    lock.releaseLock();
+    try { bumpFloorCache(); } catch (ignore2) {} lock.releaseLock();
   }
 }
 
@@ -1831,7 +1896,7 @@ function adminPauseOrder(orderNum) {
   } catch(e) {
     return {success: false, message: e.toString()};
   } finally {
-    lock.releaseLock();
+    try { bumpFloorCache(); } catch (ignore2) {} lock.releaseLock();
   }
 }
 
@@ -1859,7 +1924,7 @@ function adminResumeOrder(orderNum) {
   } catch(e) {
     return {success: false, message: e.toString()};
   } finally {
-    lock.releaseLock();
+    try { bumpFloorCache(); } catch (ignore2) {} lock.releaseLock();
   }
 }
 
@@ -1915,7 +1980,7 @@ function processPdfQueue() {
       file.setName("ERROR_" + file.getName());
     }
   } finally {
-    lock.releaseLock();
+    try { bumpFloorCache(); } catch (ignore2) {} lock.releaseLock();
   }
 }
 
@@ -2446,15 +2511,23 @@ function leaveBatchForOrder(workerName, keepOrder) {
     writeLogMeta(logSheet, j + 1, m);
     syncLegacyPauseCells(logSheet, j + 1, m, logs[j][4]);
   }
+  bumpFloorCache();
   return { success: true };
 }
 
 function ensureIdleTrigger() {
+  try {
+    if (CacheService.getScriptCache().get("idleTriggerOk")) return;
+  } catch (e) {}
   var triggers = ScriptApp.getProjectTriggers();
   for (var i = 0; i < triggers.length; i++) {
-    if (triggers[i].getHandlerFunction() === "checkIdleWorkers") return;
+    if (triggers[i].getHandlerFunction() === "checkIdleWorkers") {
+      try { CacheService.getScriptCache().put("idleTriggerOk", "1", 21600); } catch (e2) {}
+      return;
+    }
   }
   ScriptApp.newTrigger("checkIdleWorkers").timeBased().everyMinutes(5).create();
+  try { CacheService.getScriptCache().put("idleTriggerOk", "1", 21600); } catch (e3) {}
 }
 
 function getIdleAlertSheet(ss) {
@@ -2622,6 +2695,7 @@ function assignIndirectTask(workerName, taskName, assignedBy) {
       idleSheet.getRange(i + 1, 7).setValue(taskName);
     }
   }
+  bumpFloorCache();
   return { success: true };
 }
 

--- a/studio-delta-production/Code.gs
+++ b/studio-delta-production/Code.gs
@@ -372,6 +372,11 @@ function getLogPack(ss, forceFull) {
   return _logPackMemo;
 }
 
+function invalidateLogPack() {
+  _logPackMemo = null;
+  _logPackFull = false;
+}
+
 function packSheetRow(pack, valuesIndex) {
   return pack.fromRow + valuesIndex - 1;
 }
@@ -684,7 +689,94 @@ function pollFloor(role, workerName) {
   };
 }
 
-function startOrder(rowIndex, workerName, role, batchRowIndices, switchReason) {
+function uniqueOrderNums(arr) {
+  var out = [];
+  var seen = {};
+  for (var i = 0; i < (arr || []).length; i++) {
+    var o = String(arr[i] || "").trim();
+    if (!o || seen[o]) continue;
+    seen[o] = true;
+    out.push(o);
+  }
+  return out;
+}
+
+function joinWorkerOrdersTogether(ss, workerName, extraOrderNums, pack) {
+  pack = pack || getLogPack(ss);
+  var logSheet = getSheetOrDie(ss, TAB_LOGS);
+  var overviewSheet = ss.getSheetByName(TAB_OVERVIEW);
+  var now = new Date();
+  var logs = pack.values;
+  var targetMap = {};
+  (extraOrderNums || []).forEach(function(o) {
+    var n = String(o || "").trim();
+    if (n) targetMap[n] = true;
+  });
+  var open = [];
+  for (var i = 1; i < logs.length; i++) {
+    if (logs[i][6]) continue;
+    if (String(logs[i][2] || "").trim() !== String(workerName || "").trim()) continue;
+    var meta = parseLogMeta(logs[i].length > 12 ? logs[i][12] : "");
+    if (meta.entryType === "indirect") continue;
+    var paused = hasOpenPause(meta.pauses) || !!logs[i][9];
+    var ord = String(logs[i][1] || "");
+    open.push({ valuesIndex: i, meta: meta, order: ord, paused: paused });
+    if (!paused && ord) targetMap[ord] = true;
+  }
+  var targetOrders = uniqueOrderNums(Object.keys(targetMap));
+  var share = targetOrders.length;
+  if (share < 2) {
+    return { batchId: "", batchShare: 1, handled: {} };
+  }
+
+  var batchId = "";
+  for (var r = 0; r < open.length; r++) {
+    if (open[r].paused) continue;
+    if (targetOrders.indexOf(open[r].order) === -1) continue;
+    if (open[r].meta.batchId && !open[r].meta.batchSplitAt) {
+      batchId = open[r].meta.batchId;
+      break;
+    }
+  }
+  if (!batchId) batchId = Utilities.getUuid();
+
+  var handled = {};
+  for (var j = 0; j < open.length; j++) {
+    var rec = open[j];
+    if (targetOrders.indexOf(rec.order) === -1) continue;
+    if (rec.paused) {
+      rec.meta = closeOpenPauseInMeta(rec.meta, now);
+      writeLogPauseState(logSheet, packSheetRow(pack, rec.valuesIndex), rec.meta, logs[rec.valuesIndex][4]);
+    }
+    var sameBatch = rec.meta.batchId === batchId && !rec.meta.batchSplitAt && Number(rec.meta.batchShare || 1) === share;
+    if (sameBatch && !rec.paused) {
+      handled[rec.order] = true;
+      continue;
+    }
+    var sheetRow = packSheetRow(pack, rec.valuesIndex);
+    logSheet.getRange(sheetRow, 7).setValue(now);
+    pack.values[rec.valuesIndex][6] = now;
+
+    var newMeta = defaultLogMeta();
+    newMeta.batchId = batchId;
+    newMeta.batchShare = share;
+    newMeta.entryType = rec.meta.entryType || "production";
+    var row = pack.values[rec.valuesIndex];
+    var uniqueId = Utilities.getUuid();
+    logSheet.appendRow([
+      uniqueId, row[1], row[2], row[3], row[4], now, "", "", "",
+      "", "", "", JSON.stringify(newMeta)
+    ]);
+    if (overviewSheet) {
+      overviewSheet.appendRow([uniqueId, row[1], row[2], row[4], now, "", ""]);
+    }
+    handled[rec.order] = true;
+  }
+  invalidateLogPack();
+  return { batchId: batchId, batchShare: share, handled: handled };
+}
+
+function startOrder(rowIndex, workerName, role, batchRowIndices, switchReason, workTogether) {
   var lock = LockService.getScriptLock();
   lock.waitLock(10000); 
   
@@ -711,16 +803,25 @@ function startOrder(rowIndex, workerName, role, batchRowIndices, switchReason) {
       throw new Error(workerName + " is not assigned to " + role + ". Ask admin to add it on the Users sheet.");
     }
 
-    var batchId = rowsToStart.length > 1 ? Utilities.getUuid() : "";
-    var batchShare = rowsToStart.length > 1 ? rowsToStart.length : 1;
     var exceptOrders = [];
     for (var e = 0; e < rowsToStart.length; e++) {
       var er = rowsToStart[e];
       exceptOrders.push(orderData[er - 1] ? orderData[er - 1][1] : "");
     }
 
+    var batchId = rowsToStart.length > 1 ? Utilities.getUuid() : "";
+    var batchShare = rowsToStart.length > 1 ? rowsToStart.length : 1;
     var runningOthers = listRunningOrdersForWorker(pack.values, workerName, exceptOrders);
-    if (runningOthers.length && !isUserPauseReason(switchReason)) {
+
+    if (workTogether) {
+      var join = joinWorkerOrdersTogether(ss, workerName, exceptOrders, pack);
+      if (join.batchId) {
+        batchId = join.batchId;
+        batchShare = join.batchShare;
+      }
+      runningOthers = [];
+      pack = getLogPack(ss);
+    } else if (runningOthers.length && !isUserPauseReason(switchReason)) {
       return { success: false, needsSwitchReason: true, runningOrders: runningOthers, message: "Choose why you are leaving the current order." };
     }
 
@@ -2013,9 +2114,9 @@ function generatePowderCoatingList(listData, workerName) {
   }
 }
 
-function batchStartOrders(rowIndices, workerName, role, switchReason) {
+function batchStartOrders(rowIndices, workerName, role, switchReason, workTogether) {
   try {
-    return startOrder(rowIndices[0], workerName, role, rowIndices, switchReason);
+    return startOrder(rowIndices[0], workerName, role, rowIndices, switchReason, workTogether);
   } catch(e) {
     Logger.log("Batch start error: " + e);
     return {success: false, error: e.toString()};
@@ -2067,13 +2168,23 @@ function workerPauseOrder(rowIndex, orderNum, workerName, reason) {
   }
 }
 
-function workerResumeOrder(rowIndex, orderNum, workerName, switchReason) {
+function workerResumeOrder(rowIndex, orderNum, workerName, switchReason, workTogether) {
   var lock = LockService.getScriptLock();
   lock.waitLock(10000);
   try {
     var ss = getSpreadsheet();
     var pack = getLogPack(ss);
     var runningOthers = listRunningOrdersForWorker(pack.values, workerName, [orderNum]);
+    if (workTogether) {
+      closeIndirectTasksForWorker(ss, workerName, pack);
+      var join = joinWorkerOrdersTogether(ss, workerName, [orderNum], pack);
+      pack = getLogPack(ss);
+      var okTogether = resumeWorkerLog(ss, workerName, orderNum, pack);
+      if (!okTogether && !(join.handled && join.handled[String(orderNum)])) {
+        return {success: false, message: "No paused tasks found for you on this order."};
+      }
+      return {success: true, batchId: join.batchId || ""};
+    }
     if (runningOthers.length && !isUserPauseReason(switchReason)) {
       return { success: false, needsSwitchReason: true, runningOrders: runningOthers, message: "Choose why you are leaving the current order." };
     }

--- a/studio-delta-production/Code.gs
+++ b/studio-delta-production/Code.gs
@@ -30,7 +30,7 @@ var IDLE_GRACE_MINS = 10;
 var INDIRECT_TASKS = ["Cleaning", "Maintenance", "Material handling", "Waiting for materials", "Waiting for plate", "Meeting", "Training", "Other"];
 
 
-var KNOWN_FLOOR_TASKS = ["Profile Cutting", "Plate Cutting", "Tagging", "Welding", "Grinding", "Quality Control", "Assembly"];
+var KNOWN_FLOOR_TASKS = ["Profile Cutting", "Plate Cutting", "Tagging", "Welding", "Grinding", "Quality Control", "Paint Preparation", "Painting", "Assembly"];
 
 var TASK_ALIAS_MAP = {
   "profile cutting": "Profile Cutting",
@@ -51,7 +51,12 @@ var TASK_ALIAS_MAP = {
   "pre-powder": "Quality Control",
   "powder coating": "Quality Control",
   "assembly": "Assembly",
-  "assembler": "Assembly"
+  "assembler": "Assembly",
+  "paint preparation": "Paint Preparation",
+  "paint prep": "Paint Preparation",
+  "painting preparation": "Paint Preparation",
+  "painting": "Painting",
+  "painter": "Painting"
 };
 
 function ensureUsersSheetTasksColumn() {
@@ -156,7 +161,10 @@ function workerCanPerformTask(workerName, task) {
   if (!profile) return false;
   if (profile.isAdmin) return true;
   var want = canonicalTaskName(task) || String(task || "").trim();
-  return profile.tasks.indexOf(want) !== -1;
+  if (profile.tasks.indexOf(want) !== -1) return true;
+  // Assemblers may start Paint Preparation from Ready for Assembly without a separate login task.
+  if (want === "Paint Preparation" && profile.tasks.indexOf("Assembly") !== -1) return true;
+  return false;
 }
 
 
@@ -593,7 +601,9 @@ function getOrdersForRole(role, workerName) {
       'Ready for Final QC', 'Final QC',
       'Ready for Delivery', 'Out for Delivery'
     ],
-    'Assembly': ['Ready for Assembly', 'Assembly']
+    'Assembly': ['Ready for Assembly', 'Assembly', 'Paint Preparation'],
+    'Paint Preparation': ['Ready for Assembly', 'Paint Preparation'],
+    'Painting': ['Ready for Painting', 'Painting']
   };
 
   var plateCuttingStages = [
@@ -726,19 +736,7 @@ function startOrder(rowIndex, workerName, role, batchRowIndices) {
       var orderNum = orderRow[1];
       var currentStatus = orderRow[2];
 
-      var nextStatus = "";
-      if (role === 'Plate Cutting') {
-        nextStatus = "Plate Cutting";
-      } else {
-        nextStatus = getNextStatus(currentStatus);
-        if (nextStatus && nextStatus.startsWith("Ready")) {
-          while (nextStatus && nextStatus.startsWith("Ready")) { 
-            var temp = getNextStatus(nextStatus); 
-            if (!temp) break; 
-            nextStatus = temp;
-          }
-        }
-      }
+      var nextStatus = getStartStatusForRole(currentStatus, role);
 
       if (role === 'Plate Cutting') {
         var plateInfo = plateMap[String(orderNum)] || emptyPlateStatus();
@@ -1423,6 +1421,14 @@ function getAdminDashboardData() {
 
 // --- UTILS ---
 function getNextStatus(current) {
+  var currentTrimmed = String(current).trim();
+  var currentLower = currentTrimmed.toLowerCase();
+
+  // Optional paint loop: Ready for Assembly can go to Paint Preparation instead of Assembly.
+  if (currentLower === "paint preparation") return "Ready for Painting";
+  if (currentLower === "ready for painting") return "Painting";
+  if (currentLower === "painting") return "Ready for Assembly";
+
   var flow = [
     "Not Yet Started", 
     "Ready for Steelwork", "Profile Cutting", 
@@ -1430,27 +1436,46 @@ function getNextStatus(current) {
     "Ready for Welding", "Welding", 
     "Ready for Grinding", "Grinding", 
     "Ready for Pre-Powder Coating", "Pre-Powder Coating",
-    "Ready for Powder Coating", // <--- ADDED THIS STEP
+    "Ready for Powder Coating",
     "Powder Coating", 
     "Ready for Assembly", "Assembly", 
     "Ready for Final QC", "Final QC",
     "Ready for Delivery", "Out for Delivery", 
     "Delivered"
   ];
-  
-  // Case-insensitive search for current status
-  var currentTrimmed = String(current).trim();
-  var currentLower = currentTrimmed.toLowerCase();
+
   var idx = -1;
-  
   for (var i = 0; i < flow.length; i++) {
     if (flow[i].toLowerCase() === currentLower) {
       idx = i;
       break;
     }
   }
-  
+
   return (idx > -1 && idx < flow.length - 1) ? flow[idx + 1] : current; 
+}
+
+function getStartStatusForRole(currentStatus, role) {
+  var currentLower = String(currentStatus || "").trim().toLowerCase();
+  var roleLower = String(role || "").trim().toLowerCase();
+  if (roleLower === "plate cutting") return "Plate Cutting";
+  if (currentLower === "ready for assembly" && roleLower === "paint preparation") {
+    return "Paint Preparation";
+  }
+  if (currentLower === "ready for painting" && (roleLower === "painting" || roleLower === "painter")) {
+    return "Painting";
+  }
+  if (currentLower === "paint preparation") return "Paint Preparation";
+  if (currentLower === "painting") return "Painting";
+  var nextStatus = getNextStatus(currentStatus);
+  if (nextStatus && String(nextStatus).indexOf("Ready") === 0) {
+    while (nextStatus && String(nextStatus).indexOf("Ready") === 0) {
+      var temp = getNextStatus(nextStatus);
+      if (!temp || temp === nextStatus) break;
+      nextStatus = temp;
+    }
+  }
+  return nextStatus;
 }
 
 /**
@@ -1501,8 +1526,8 @@ function isAllowedStatus(status) {
     // Powder Coating
     "ready for pre-powder coating", "pre-powder coating",
     "ready for powder coating", "powder coating", 
-    // Assembly & QC
-    "ready for assembly", "assembly", 
+    // Assembly, painting & QC
+    "ready for assembly", "paint preparation", "ready for painting", "painting", "assembly", 
     "ready for final qc", "final qc",
     // Delivery
     "ready for delivery", "out for delivery"
@@ -1667,6 +1692,8 @@ function sortProcessesByWorkflow(processes) {
     'Welding',
     'Grinding',
     'Powder Coating',
+    'Paint Preparation',
+    'Painting',
     'Assembly'
   ];
   

--- a/studio-delta-production/README.md
+++ b/studio-delta-production/README.md
@@ -6,8 +6,8 @@ Timezone: **Africa/Johannesburg**. The paid shift is **07:45–15:45** with a **
 
 ## Floor rules
 
-- One person has **one running clock**. Extra open jobs are paused automatically. Pausing or switching requires **No materials**, **Touch up** (plus the order number), or **Other**. Activity and the Workers hour log split those hours by calendar day and show each bout with the pause reason — not a single start-minus-end total.
-- Same product, same process (e.g. assembly slats for two matching gates) can be **batched**: one clock, time split across the orders. Use **Work this order only** to leave the batch.
+- One person has **one running clock**. Starting or resuming another order asks **Switch from A to B** (pause A, start B — still needs a reason) or **Work on A and B** (one clock, time split; Together badge). **Work this order only** leaves a batch. Pausing or switching requires **No materials**, **Touch up** (plus the order number), or **Other**. Activity and the Workers hour log split those hours by calendar day and show each bout with the pause reason — not a single start-minus-end total.
+- Same product, same process (e.g. assembly slats for two matching gates) can still be started together from Available. Use **Work this order only** to leave a batch.
 - When plate cutting finishes on an order, welders waiting on that plate are **auto-switched** back. They can tap **Still on other job** if they are not ready.
 - **Ready for Assembly** can go to **Assembly** or **Paint Preparation**. Assemblers see both buttons. Paint prep finish → **Ready for Painting**. Painters (Users task `Painting`) see those orders; painting finish → **Ready for Assembly** so assembly can happen.
 - If nobody has a running job for more than ~10 minutes during shift hours (07:45–15:45 weekdays), **Admin and QC who currently have the app open** get a popup modal listing those idle people. Assign an **indirect task** from the popup (or from Admin → Workers). Starting a real order closes that task. Idle alerts are **not** emailed.

--- a/studio-delta-production/README.md
+++ b/studio-delta-production/README.md
@@ -6,7 +6,7 @@ Timezone: **Africa/Johannesburg**. The paid shift is **07:45–15:45** with a **
 
 ## Floor rules
 
-- One person has **one running clock**. Extra open jobs are paused automatically.
+- One person has **one running clock**. Extra open jobs are paused automatically. Pausing or switching requires **No materials**, **Touch up** (plus the order number), or **Other**. Activity splits those hours by day and shows each bout with the pause reason — not a single start-minus-end total.
 - Same product, same process (e.g. assembly slats for two matching gates) can be **batched**: one clock, time split across the orders. Use **Work this order only** to leave the batch.
 - When plate cutting finishes on an order, welders waiting on that plate are **auto-switched** back. They can tap **Still on other job** if they are not ready.
 - **Ready for Assembly** can go to **Assembly** or **Paint Preparation**. Assemblers see both buttons. Paint prep finish → **Ready for Painting**. Painters (Users task `Painting`) see those orders; painting finish → **Ready for Assembly** so assembly can happen.
@@ -55,4 +55,4 @@ Assembly and Final QC must log **which backboard was used**, the same way plate/
 
 ## Activity report
 
-Admin sidebar → **Activity**. Daily / weekly / monthly view of what each person did, with regular hours capped at 7.5h per day and overtime shown separately.
+Admin sidebar → **Activity**. Daily / weekly / monthly view of what each person did, with regular hours capped at 7.5h per day and overtime shown separately. Overnight jobs and pause/resume bouts are split by calendar day, and each pause shows **when** and **why**.

--- a/studio-delta-production/README.md
+++ b/studio-delta-production/README.md
@@ -41,7 +41,7 @@ Add a **Tasks** column (column D). The first time the app opens it will create t
 
 The tablet does **not** remember the last login. After Log Out (or a refresh) everyone sees the login screen again.
 
-Floor screens cache order lists for about 20 seconds and only reread the spreadsheet after a start, pause, finish, or similar change. Auto-refresh is once a minute while the tab is visible.
+Floor boards read only the latest production-log rows (not the whole history) and cache the order list for about 90 seconds. Start/pause/finish reuse that same log slice instead of rereading the sheet several times. Auto-refresh is once a minute while the tab is visible.
 
 Assembly and Final QC must log **which backboard was used**, the same way plate/profile cutting logs steel. Add backboard names on the `Backboards` sheet (Category, Profile Name), or pick Custom during QC.
 

--- a/studio-delta-production/README.md
+++ b/studio-delta-production/README.md
@@ -2,11 +2,11 @@
 
 Google Apps Script shop-floor app for Studio Delta (South Africa). Paste `Code.gs` and `index.html` into the Apps Script project bound to the production spreadsheet. The HTML file **must** be named `index` in the script editor.
 
-Timezone: **Africa/Johannesburg**. The paid shift is **07:45–15:45** with a **30-minute break 12:00–12:30** (7.5 hours / 450 minutes). Minutes after that on a calendar day are overtime. Overnight jobs are split by calendar day on Activity (e.g. 14:00 yesterday–10:00 today → yesterday 14:00–15:45 and today 07:45–10:00).
+Timezone: **Africa/Johannesburg**. The paid shift is **07:45–15:45** with a **30-minute break 12:00–12:30** (7.5 hours / 450 minutes). Minutes after that on a calendar day are overtime. Overnight jobs are split by calendar day on Activity and on Admin → Workers (e.g. 14:00 yesterday–10:00 today → yesterday 14:00–15:45 and today 07:45–10:00).
 
 ## Floor rules
 
-- One person has **one running clock**. Extra open jobs are paused automatically. Pausing or switching requires **No materials**, **Touch up** (plus the order number), or **Other**. Activity splits those hours by day and shows each bout with the pause reason — not a single start-minus-end total.
+- One person has **one running clock**. Extra open jobs are paused automatically. Pausing or switching requires **No materials**, **Touch up** (plus the order number), or **Other**. Activity and the Workers hour log split those hours by calendar day and show each bout with the pause reason — not a single start-minus-end total.
 - Same product, same process (e.g. assembly slats for two matching gates) can be **batched**: one clock, time split across the orders. Use **Work this order only** to leave the batch.
 - When plate cutting finishes on an order, welders waiting on that plate are **auto-switched** back. They can tap **Still on other job** if they are not ready.
 - **Ready for Assembly** can go to **Assembly** or **Paint Preparation**. Assemblers see both buttons. Paint prep finish → **Ready for Painting**. Painters (Users task `Painting`) see those orders; painting finish → **Ready for Assembly** so assembly can happen.
@@ -55,4 +55,4 @@ Assembly and Final QC must log **which backboard was used**, the same way plate/
 
 ## Activity report
 
-Admin sidebar → **Activity**. Daily / weekly / monthly view of what each person did, with regular hours capped at 7.5h per day and overtime shown separately. Overnight jobs and pause/resume bouts are split by calendar day, and each pause shows **when** and **why**.
+Admin sidebar → **Activity**. Daily / weekly / monthly view of what each person did, with regular hours capped at 7.5h per day and overtime shown separately. Overnight jobs and pause/resume bouts are split by calendar day, and each pause shows **when** and **why**. Admin → **Workers** uses the same per-day split for the hour log (one row per calendar day) and weekly totals.

--- a/studio-delta-production/README.md
+++ b/studio-delta-production/README.md
@@ -39,6 +39,8 @@ Add a **Tasks** column (column D). The first time the app opens it will create t
 
 The tablet remembers the last login until they tap Log Out.
 
+Floor screens cache order lists for about 20 seconds and only reread the spreadsheet after a start, pause, finish, or similar change. Auto-refresh is once a minute while the tab is visible.
+
 ## First deploy
 
 1. Replace the existing `Code.gs` and `index` HTML with these files.

--- a/studio-delta-production/README.md
+++ b/studio-delta-production/README.md
@@ -9,20 +9,22 @@ Timezone: **Africa/Johannesburg**. A standard work day is **8 hours (480 minutes
 - One person has **one running clock**. Extra open jobs are paused automatically.
 - Same product, same process (e.g. assembly slats for two matching gates) can be **batched**: one clock, time split across the orders. Use **Work this order only** to leave the batch.
 - When plate cutting finishes on an order, welders waiting on that plate are **auto-switched** back. They can tap **Still on other job** if they are not ready.
-- If nobody has a running job for more than ~10 minutes during shift hours (07:00–17:00 weekdays), admin gets an email. Admin can assign an **indirect task**. Starting a real order closes that task.
+- If nobody has a running job for more than ~10 minutes during shift hours (07:00–17:00 weekdays), **Admin and QC who currently have the app open** get a popup modal listing those idle people. Assign an **indirect task** from the popup (or from Admin → Workers). Starting a real order closes that task. Idle alerts are **not** emailed.
 
 ## New spreadsheet pieces
 
 | Sheet / column | Purpose |
 | --- | --- |
 | `Production_Log` column M | JSON meta: pause intervals, batch id, share, entry type |
-| `Idle_Alerts` | One row per idle email so the same person is not emailed twice in a day |
+| `Idle_Alerts` | Open idle people for the day. Admin/QC popups read this list; assigning a task sets Status to Assigned |
+| `Backboards` | Category + profile name list for assembly / final QC (same idea as `Steel_Profiles`) |
+| `Backboard_Usage` | Timestamp, order, worker, process, type, size logged when assembly or final QC is finished |
 
 Legacy pause columns J/K/L are still written for older reports.
 
-## Users sheet (login once)
+## Users sheet (login)
 
-Workers log in **once** with name + access code. They no longer pick a role first.
+Workers log in **once per visit** with name + access code. Every page load shows the login screen first (the last login is not remembered).
 
 Add a **Tasks** column (column D). The first time the app opens it will create the header if it is missing.
 
@@ -37,9 +39,11 @@ Add a **Tasks** column (column D). The first time the app opens it will create t
 - Anyone else only sees the tasks listed. `Welding, Tagging` (or a role like `Welder Tagger`) means they pick Welding or Tagging after login, and only those boards appear.
 - If Tasks is blank, the app reads the Role cell (`Welder Tagger` → Welding + Tagging).
 
-The tablet remembers the last login until they tap Log Out.
+The tablet does **not** remember the last login. After Log Out (or a refresh) everyone sees the login screen again.
 
 Floor screens cache order lists for about 20 seconds and only reread the spreadsheet after a start, pause, finish, or similar change. Auto-refresh is once a minute while the tab is visible.
+
+Assembly and Final QC must log **which backboard was used**, the same way plate/profile cutting logs steel. Add backboard names on the `Backboards` sheet (Category, Profile Name), or pick Custom during QC.
 
 ## First deploy
 

--- a/studio-delta-production/README.md
+++ b/studio-delta-production/README.md
@@ -2,14 +2,14 @@
 
 Google Apps Script shop-floor app for Studio Delta (South Africa). Paste `Code.gs` and `index.html` into the Apps Script project bound to the production spreadsheet. The HTML file **must** be named `index` in the script editor.
 
-Timezone: **Africa/Johannesburg**. A standard work day is **8 hours (480 minutes)**. Anything above that on a calendar day is overtime.
+Timezone: **Africa/Johannesburg**. The paid shift is **07:45–15:45** with a **30-minute break 12:00–12:30** (7.5 hours / 450 minutes). Minutes after that on a calendar day are overtime. Overnight jobs are split by calendar day on Activity (e.g. 14:00 yesterday–10:00 today → yesterday 14:00–15:45 and today 07:45–10:00).
 
 ## Floor rules
 
 - One person has **one running clock**. Extra open jobs are paused automatically.
 - Same product, same process (e.g. assembly slats for two matching gates) can be **batched**: one clock, time split across the orders. Use **Work this order only** to leave the batch.
 - When plate cutting finishes on an order, welders waiting on that plate are **auto-switched** back. They can tap **Still on other job** if they are not ready.
-- If nobody has a running job for more than ~10 minutes during shift hours (07:00–17:00 weekdays), **Admin and QC who currently have the app open** get a popup modal listing those idle people. Assign an **indirect task** from the popup (or from Admin → Workers). Starting a real order closes that task. Idle alerts are **not** emailed.
+- If nobody has a running job for more than ~10 minutes during shift hours (07:45–15:45 weekdays), **Admin and QC who currently have the app open** get a popup modal listing those idle people. Assign an **indirect task** from the popup (or from Admin → Workers). Starting a real order closes that task. Idle alerts are **not** emailed.
 
 ## New spreadsheet pieces
 

--- a/studio-delta-production/README.md
+++ b/studio-delta-production/README.md
@@ -1,0 +1,31 @@
+# Studio Delta Production
+
+Google Apps Script shop-floor app for Studio Delta (South Africa). Paste `Code.gs` and `index.html` into the Apps Script project bound to the production spreadsheet. The HTML file **must** be named `index` in the script editor.
+
+Timezone: **Africa/Johannesburg**. A standard work day is **8 hours (480 minutes)**. Anything above that on a calendar day is overtime.
+
+## Floor rules
+
+- One person has **one running clock**. Extra open jobs are paused automatically.
+- Same product, same process (e.g. assembly slats for two matching gates) can be **batched**: one clock, time split across the orders. Use **Work this order only** to leave the batch.
+- When plate cutting finishes on an order, welders waiting on that plate are **auto-switched** back. They can tap **Still on other job** if they are not ready.
+- If nobody has a running job for more than ~10 minutes during shift hours (07:00–17:00 weekdays), admin gets an email. Admin can assign an **indirect task**. Starting a real order closes that task.
+
+## New spreadsheet pieces
+
+| Sheet / column | Purpose |
+| --- | --- |
+| `Production_Log` column M | JSON meta: pause intervals, batch id, share, entry type |
+| `Idle_Alerts` | One row per idle email so the same person is not emailed twice in a day |
+
+Legacy pause columns J/K/L are still written for older reports.
+
+## First deploy
+
+1. Replace the existing `Code.gs` and `index` HTML with these files.
+2. Open the web app once as admin. `doGet` tries to create a 5-minute idle check trigger.
+3. Confirm **Project Settings → Time zone** is `Africa/Johannesburg`.
+
+## Activity report
+
+Admin sidebar → **Activity**. Daily / weekly / monthly view of what each person did, with regular hours capped at 8h per day and overtime shown separately.

--- a/studio-delta-production/README.md
+++ b/studio-delta-production/README.md
@@ -20,6 +20,25 @@ Timezone: **Africa/Johannesburg**. A standard work day is **8 hours (480 minutes
 
 Legacy pause columns J/K/L are still written for older reports.
 
+## Users sheet (login once)
+
+Workers log in **once** with name + access code. They no longer pick a role first.
+
+Add a **Tasks** column (column D). The first time the app opens it will create the header if it is missing.
+
+| Name | Role | Password | Tasks |
+| --- | --- | --- | --- |
+| Sipho | Welder Tagger | 1234 | Welding, Tagging |
+| Thabo | Quality Control | 1234 | Quality Control |
+| Admin | Admin | **** | |
+
+- **Admin** sees Production, Workers, Metrics, QC Reports, Activity, and can open any floor task.
+- **Quality Control / QC** only sees QC work.
+- Anyone else only sees the tasks listed. `Welding, Tagging` (or a role like `Welder Tagger`) means they pick Welding or Tagging after login, and only those boards appear.
+- If Tasks is blank, the app reads the Role cell (`Welder Tagger` → Welding + Tagging).
+
+The tablet remembers the last login until they tap Log Out.
+
 ## First deploy
 
 1. Replace the existing `Code.gs` and `index` HTML with these files.

--- a/studio-delta-production/README.md
+++ b/studio-delta-production/README.md
@@ -9,6 +9,7 @@ Timezone: **Africa/Johannesburg**. The paid shift is **07:45–15:45** with a **
 - One person has **one running clock**. Extra open jobs are paused automatically.
 - Same product, same process (e.g. assembly slats for two matching gates) can be **batched**: one clock, time split across the orders. Use **Work this order only** to leave the batch.
 - When plate cutting finishes on an order, welders waiting on that plate are **auto-switched** back. They can tap **Still on other job** if they are not ready.
+- **Ready for Assembly** can go to **Assembly** or **Paint Preparation**. Assemblers see both buttons. Paint prep finish → **Ready for Painting**. Painters (Users task `Painting`) see those orders; painting finish → **Ready for Assembly** so assembly can happen.
 - If nobody has a running job for more than ~10 minutes during shift hours (07:45–15:45 weekdays), **Admin and QC who currently have the app open** get a popup modal listing those idle people. Assign an **indirect task** from the popup (or from Admin → Workers). Starting a real order closes that task. Idle alerts are **not** emailed.
 
 ## New spreadsheet pieces
@@ -37,6 +38,7 @@ Add a **Tasks** column (column D). The first time the app opens it will create t
 - **Admin** sees Production, Workers, Metrics, QC Reports, Activity, and can open any floor task.
 - **Quality Control / QC** only sees QC work.
 - Anyone else only sees the tasks listed. `Welding, Tagging` (or a role like `Welder Tagger`) means they pick Welding or Tagging after login, and only those boards appear.
+- Painters need `Painting` on the Tasks column. Assemblers with `Assembly` also get **Paint prep** on Ready for Assembly cards (no extra task required).
 - If Tasks is blank, the app reads the Role cell (`Welder Tagger` → Welding + Tagging).
 
 The tablet does **not** remember the last login. After Log Out (or a refresh) everyone sees the login screen again.
@@ -53,4 +55,4 @@ Assembly and Final QC must log **which backboard was used**, the same way plate/
 
 ## Activity report
 
-Admin sidebar → **Activity**. Daily / weekly / monthly view of what each person did, with regular hours capped at 8h per day and overtime shown separately.
+Admin sidebar → **Activity**. Daily / weekly / monthly view of what each person did, with regular hours capped at 7.5h per day and overtime shown separately.

--- a/studio-delta-production/README.md
+++ b/studio-delta-production/README.md
@@ -9,7 +9,7 @@ Timezone: **Africa/Johannesburg**. The paid shift is **07:45–15:45** with a **
 - One person has **one running clock**. Starting or resuming another order asks **Switch from A to B** (pause A, start B — still needs a reason) or **Work on A and B** (one clock, time split; Together badge). **Work this order only** leaves a batch. Pausing or switching requires **No materials**, **Touch up** (plus the order number), or **Other**. Activity and the Workers hour log split those hours by calendar day and show each bout with the pause reason — not a single start-minus-end total.
 - Same product, same process (e.g. assembly slats for two matching gates) can still be started together from Available. Use **Work this order only** to leave a batch.
 - When plate cutting finishes on an order, welders waiting on that plate are **auto-switched** back. They can tap **Still on other job** if they are not ready.
-- **Ready for Assembly** can go to **Assembly** or **Paint Preparation**. Assemblers see both buttons. Paint prep finish → **Ready for Painting**. Painters (Users task `Painting`) see those orders; painting finish → **Ready for Assembly** so assembly can happen.
+- **Ready for Assembly** can go to **Assembly** or **Paint Preparation**. Assemblers see **Assemble** and **Paint prep**. Painters (Users task `Painting`) also see Ready for Assembly and can **Start paint prep**, then paint. Paint prep finish → **Ready for Painting**. Painting finish → **Ready for Assembly** so assembly can happen.
 - If nobody has a running job for more than ~10 minutes during shift hours (07:45–15:45 weekdays), **Admin and QC who currently have the app open** get a popup modal listing those idle people. Assign an **indirect task** from the popup (or from Admin → Workers). Starting a real order closes that task. Idle alerts are **not** emailed.
 
 ## New spreadsheet pieces
@@ -38,7 +38,7 @@ Add a **Tasks** column (column D). The first time the app opens it will create t
 - **Admin** sees Production, Workers, Metrics, QC Reports, Activity, and can open any floor task.
 - **Quality Control / QC** only sees QC work.
 - Anyone else only sees the tasks listed. `Welding, Tagging` (or a role like `Welder Tagger`) means they pick Welding or Tagging after login, and only those boards appear.
-- Painters need `Painting` on the Tasks column. Assemblers with `Assembly` also get **Paint prep** on Ready for Assembly cards (no extra task required).
+- Painters need `Painting` on the Tasks column. That also lets them prep items for painting (no extra `Paint Preparation` task required). Assemblers with `Assembly` also get **Paint prep** on Ready for Assembly cards.
 - If Tasks is blank, the app reads the Role cell (`Welder Tagger` → Welding + Tagging).
 
 The tablet does **not** remember the last login. After Log Out (or a refresh) everyone sees the login screen again.

--- a/studio-delta-production/index.html
+++ b/studio-delta-production/index.html
@@ -3,7 +3,7 @@
 <head>
   <base target="_top">
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <title>Studio Delta</title>
   
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Outfit:wght@400;600;700&family=Playfair+Display:wght@400;600;700&display=swap" rel="stylesheet">
@@ -448,28 +448,9 @@
        RESPONSIVE — MOBILE
        ===================================================== */
     @media (max-width: 768px) {
-      .mobile-menu-btn { display: flex; }
-      .mobile-backdrop { display: block; }
-      .container-fluid { padding-left: 12px !important; padding-right: 12px !important; padding-top: 68px !important; }
-      h1.display-4 { font-size: 2rem; }
       h2 { font-size: 1.5rem; }
       h3 { font-size: 1.25rem; }
-      h4 { font-size: 1.1rem; }
-      .sidebar { width: 280px; left: -280px; box-shadow: var(--shadow-lg); }
-      .sidebar.mobile-open { left: 0; }
-      .sidebar-link { padding: 14px 12px; }
-      .sidebar-link i { font-size: 1.7rem; }
-      .sidebar-link .link-text { font-size: 0.8rem; }
-      .main-content { margin-left: 0; }
-      .card { margin-bottom: 1rem; }
-      .card-body { padding: 1rem; }
-      .btn { padding: 0.7rem 1rem; font-size: 0.9rem; min-height: 44px; }
-      .btn-sm { min-height: 36px; }
-      .nav-pills { flex-direction: column; }
-      .nav-pills .nav-link { margin-bottom: 0.4rem; text-align: center; }
-      .form-control { font-size: 16px; padding: 0.7rem; min-height: 44px; }
-      .modal-dialog { margin: 0.5rem; }
-      .table { font-size: 0.82rem; }
+      .form-control, .form-select { font-size: 16px; min-height: 44px; }
       #sigCanvas { height: 150px; }
       #adminProdTabs { flex-wrap: wrap; }
       #adminProdTabs .nav-link { font-size: 0.82rem; padding: 0.5rem; }
@@ -684,9 +665,108 @@
     .idle-card { border: 1px dashed var(--border-strong); }
     .product-sub { font-size: 0.75rem; color: var(--text-secondary); font-weight: 500; }
     .hours-regular { font-variant-numeric: tabular-nums; }
+
+    /* =====================================================
+       LOGIN + TASK PICKER + RESPONSIVE SHELL
+       ===================================================== */
+    body:not(.is-logged-in) .sidebar,
+    body:not(.is-logged-in) .mobile-menu-btn,
+    body:not(.is-logged-in) .mobile-backdrop {
+      display: none !important;
+    }
+    body:not(.is-logged-in) .main-content { margin-left: 0; }
+    body:not(.is-logged-in) .main-content .container-fluid {
+      padding-top: 24px;
+      min-height: 100dvh;
+    }
+
+    .login-shell {
+      min-height: calc(100dvh - 80px);
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      padding: 24px 0 40px;
+    }
+    .login-card .form-control {
+      min-height: 48px;
+      font-size: 16px;
+    }
+    .task-card {
+      cursor: pointer;
+      min-height: 120px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      text-align: center;
+      padding: 24px 16px;
+    }
+    .task-card i { font-size: 1.8rem; color: var(--text-secondary); }
+    .task-card h4 { margin: 0; font-size: 1.15rem; }
+    .dash-head {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+    .order-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 0;
+    }
+    @media (min-width: 992px) {
+      :root { --sidebar-width: 220px; }
+      .sidebar { padding: 20px 12px; }
+      .sidebar-header { text-align: left; padding: 0 8px 8px; }
+      .sidebar-header h5 { font-size: 0.95rem; letter-spacing: 0.12em; }
+      .sidebar-link {
+        flex-direction: row;
+        justify-content: flex-start;
+        gap: 12px;
+        padding: 11px 14px;
+      }
+      .sidebar-link i { font-size: 1.25rem; margin-bottom: 0; }
+      .sidebar-link .link-text { font-size: 0.85rem; text-align: left; }
+      .theme-toggle-btn { flex-direction: row; gap: 8px; }
+      .theme-toggle-btn i { font-size: 1.1rem; }
+      .main-content .container-fluid { padding: 32px 2rem 4rem; }
+      .order-grid { grid-template-columns: 1fr 1fr; gap: 1rem; }
+      .checkbox-wrapper-16 { margin-bottom: 0; }
+      .view-section.container { max-width: 1180px; }
+    }
+    @media (max-width: 991.98px) {
+      .mobile-menu-btn { display: flex; top: max(12px, env(safe-area-inset-top)); left: max(12px, env(safe-area-inset-left)); }
+      .mobile-backdrop { display: block; }
+      .container-fluid { padding-left: 12px !important; padding-right: 12px !important; padding-top: 72px !important; }
+      .sidebar {
+        width: min(300px, 86vw);
+        left: -310px;
+        padding-top: max(16px, env(safe-area-inset-top));
+        padding-bottom: max(16px, env(safe-area-inset-bottom));
+        box-shadow: var(--shadow-lg);
+      }
+      .sidebar.mobile-open { left: 0; }
+      .sidebar-link { flex-direction: row; justify-content: flex-start; gap: 12px; padding: 14px 14px; }
+      .sidebar-link i { margin-bottom: 0; }
+      .main-content { margin-left: 0; }
+      .nav-pills { flex-wrap: nowrap; overflow-x: auto; }
+      .nav-pills .nav-link { white-space: nowrap; min-height: 44px; }
+      #batchActionContainer { flex-direction: column; align-items: stretch !important; gap: 8px; }
+      .floor-banner.show { flex-direction: column; align-items: stretch; }
+      .table-responsive { -webkit-overflow-scrolling: touch; }
+    }
+    @media (max-width: 575.98px) {
+      h1.display-4 { font-size: 2rem; }
+      .dash-head h4 { font-size: 1.15rem; }
+      .card-body { padding: 1rem; }
+      .btn { min-height: 44px; }
+      .modal-dialog { margin: 0.6rem; }
+    }
   </style>
 </head>
-<body>
+<body class="">
 
   <div id="loader" class="position-fixed top-0 start-0 w-100 h-100 bg-white d-flex flex-column justify-content-center align-items-center" style="z-index:9999;">
     <h2 class="brand-font mb-3">STUDIO DELTA</h2>
@@ -705,9 +785,13 @@
     <div class="sidebar-header">
       <h5 class="brand-font mb-0">STUDIO DELTA</h5>
     </div>
-    <a id="link-roles" class="sidebar-link active" onclick="navTo('view-roles')">
+    <a id="link-roles" class="sidebar-link active" onclick="goHome()">
       <i class="bi bi-house-door"></i>
       <span class="link-text">Home</span>
+    </a>
+    <a id="link-floor" class="sidebar-link d-none-view" onclick="showTaskPicker()">
+      <i class="bi bi-tools"></i>
+      <span class="link-text">Floor</span>
     </a>
     <div id="adminLinks" class="d-none-view">
       <a id="link-prod" class="sidebar-link" onclick="loadProductionOverview()">
@@ -744,30 +828,36 @@
   <div class="container-fluid">
     
     <div id="view-global-login" class="view-section container">
-      <div class="text-center mb-5 mt-5">
-        <h1 class="display-4 fw-bold">Studio Delta</h1>
-        <p class="text-muted small text-uppercase">Production Management System</p>
-      </div>
-      <div class="row justify-content-center">
-        <div class="col-md-6 col-lg-4">
-          <div class="card p-4 shadow-sm animate-card">
-            <h4 class="mb-4 text-center">App Login</h4>
-            <div class="mb-3">
-              <label class="form-label">Name</label>
-              <input type="text" id="globalLoginName" class="form-control" placeholder="Enter your name">
+      <div class="login-shell">
+        <div class="text-center mb-4">
+          <h1 class="display-4 fw-bold">Studio Delta</h1>
+          <p class="text-muted small text-uppercase mb-0">Production Management System</p>
+        </div>
+        <div class="row justify-content-center">
+          <div class="col-12 col-sm-8 col-md-6 col-lg-4">
+            <div class="card p-4 shadow-sm animate-card login-card">
+              <h4 class="mb-2 text-center">Log in</h4>
+              <p class="text-muted small text-center mb-4">One login. Then pick the work you will do today.</p>
+              <div class="mb-3">
+                <label class="form-label">Name</label>
+                <input type="text" id="globalLoginName" class="form-control" placeholder="Your name" autocomplete="username" autocapitalize="words">
+              </div>
+              <div class="mb-4">
+                <label class="form-label">Access code</label>
+                <input type="password" id="globalLoginPass" class="form-control" placeholder="Access code" autocomplete="current-password">
+              </div>
+              <button id="btnGlobalLogin" class="btn btn-primary w-100 py-2 fw-bold" onclick="submitGlobalLogin()">LOG IN</button>
             </div>
-            <div class="mb-4">
-              <label class="form-label">Password</label>
-              <input type="password" id="globalLoginPass" class="form-control" placeholder="Enter access code">
-            </div>
-            <button id="btnGlobalLogin" class="btn btn-primary w-100 py-2 fw-bold" onclick="submitGlobalLogin()">UNLOCK APP</button>
           </div>
         </div>
       </div>
     </div>
 
     <div id="view-roles" class="view-section container d-none-view">
-      <div class="text-center mb-5"><h1 class="display-4 fw-bold">Studio Delta</h1><p class="text-muted small text-uppercase">Production Management System</p></div>
+      <div class="text-center mb-4 mt-2">
+        <h1 class="h2 fw-bold mb-1">Choose your work</h1>
+        <p class="text-muted mb-0" id="taskPickSubtitle">Select the task you will do now.</p>
+      </div>
       <div class="row g-3" id="roleGrid"></div>
     </div>
 
@@ -788,8 +878,12 @@
           <button class="btn btn-sm btn-warning" id="btnStillOnOther" onclick="undoSwitch()">STILL ON OTHER JOB</button>
         </div>
       </div>
-      <div class="d-flex justify-content-between align-items-center mb-4 border-bottom pb-2">
-        <div><h4 class="m-0" id="dashUser">User</h4><small class="text-muted text-uppercase" id="dashRole">Role</small></div>
+      <div class="dash-head mb-4 border-bottom pb-3">
+        <div>
+          <h4 class="m-0" id="dashUser">User</h4>
+          <small class="text-muted text-uppercase" id="dashRole">Role</small>
+        </div>
+        <button id="btnSwitchTask" class="btn btn-outline-dark btn-sm d-none" onclick="showTaskPicker()">Switch task</button>
       </div>
       
       <div class="row mb-3">
@@ -833,8 +927,8 @@
       </div>
       
       <div class="tab-content">
-        <div class="tab-pane fade show active" id="pane-available"><div id="container-available"></div></div>
-        <div class="tab-pane fade" id="pane-progress"><div id="container-progress"></div></div>
+        <div class="tab-pane fade show active" id="pane-available"><div id="container-available" class="order-grid"></div></div>
+        <div class="tab-pane fade" id="pane-progress"><div id="container-progress" class="order-grid"></div></div>
       </div>
     </div>
 
@@ -1304,7 +1398,7 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <script>
     let appData = { users:[], workerStats: {}, currentOrders:[], steelProfiles:[] };
-    let session = { role: null, name: null, pendingRow: null, activeOrder: null, logId: null, logIds: {}, isAdmin: false, pendingBatchRows: null, pendingBatchMates: [] };
+    let session = { role: null, name: null, pendingRow: null, activeOrder: null, logId: null, logIds: {}, isAdmin: false, isQcOnly: false, tasks: [], jobTitle: '', pendingBatchRows: null, pendingBatchMates: [] };
     let activityChart = null;
     let batchWorkModal = null;
     let refreshInterval = null;
@@ -1315,7 +1409,7 @@
     let comparisonChart = null;
     
     // Mobile breakpoint constant
-    const MOBILE_BREAKPOINT = 768;
+    const MOBILE_BREAKPOINT = 992;
 
     // --- QC DATA ---
     const QC_DATA = {
@@ -1428,6 +1522,10 @@
     document.addEventListener('DOMContentLoaded', () => {
       // Initialize mobile menu first (doesn't depend on Bootstrap)
       initMobileMenu();
+      ['globalLoginName', 'globalLoginPass'].forEach(id => {
+        const el = document.getElementById(id);
+        if (el) el.addEventListener('keydown', e => { if (e.key === 'Enter') submitGlobalLogin(); });
+      });
       
       // Initialize Bootstrap modals (wrapped in try-catch in case Bootstrap doesn't load)
       try {
@@ -1515,7 +1613,8 @@
       document.getElementById(viewId).classList.remove('d-none-view');
       document.querySelectorAll('.sidebar-link').forEach(l => l.classList.remove('active'));
       let linkId = '';
-      if(viewId === 'view-global-login' || viewId === 'view-roles' || viewId === 'view-users' || viewId === 'view-dashboard') linkId = 'link-roles';
+      if(viewId === 'view-global-login' || viewId === 'view-users' || viewId === 'view-dashboard') linkId = 'link-roles';
+      if(viewId === 'view-roles') linkId = document.getElementById('link-floor') && !document.getElementById('link-floor').classList.contains('d-none-view') ? 'link-floor' : 'link-roles';
       if(viewId === 'view-admin-prod') linkId = 'link-prod';
       if(viewId === 'view-admin-workers') linkId = 'link-work';
       if(viewId === 'view-admin-metrics') linkId = 'link-metrics';
@@ -1525,6 +1624,126 @@
       if(viewId !== 'view-dashboard') stopAutoRefresh();
     }
 
+    const TASK_ICONS = {
+      'Profile Cutting': 'bi-scissors',
+      'Plate Cutting': 'bi-square',
+      'Tagging': 'bi-tag',
+      'Welding': 'bi-lightning',
+      'Grinding': 'bi-disc',
+      'Quality Control': 'bi-clipboard-check',
+      'Assembly': 'bi-box-seam'
+    };
+
+    function persistSession() {
+      try {
+        localStorage.setItem('sd-session', JSON.stringify({
+          name: session.name,
+          role: session.role,
+          isAdmin: session.isAdmin,
+          isQcOnly: session.isQcOnly,
+          tasks: session.tasks || [],
+          jobTitle: session.jobTitle || ''
+        }));
+      } catch (e) {}
+    }
+    function clearPersistedSession() {
+      try { localStorage.removeItem('sd-session'); } catch (e) {}
+    }
+    function restoreSession() {
+      try {
+        const raw = localStorage.getItem('sd-session');
+        if (!raw) return false;
+        const s = JSON.parse(raw);
+        if (!s || !s.name) return false;
+        session.name = s.name;
+        session.role = s.role || null;
+        session.isAdmin = !!s.isAdmin;
+        session.isQcOnly = !!s.isQcOnly;
+        session.tasks = s.tasks || [];
+        session.jobTitle = s.jobTitle || '';
+        return true;
+      } catch (e) { return false; }
+    }
+    function setLoggedIn(on) {
+      document.body.classList.toggle('is-logged-in', !!on);
+    }
+    function applyLoginProfile(res) {
+      session.name = res.name;
+      session.jobTitle = res.jobTitle || res.role || '';
+      session.isAdmin = !!res.isAdmin;
+      session.isQcOnly = !!res.isQcOnly;
+      session.tasks = res.tasks || [];
+      session.role = null;
+      setLoggedIn(true);
+      if (session.isAdmin) {
+        document.getElementById('adminLinks').classList.remove('d-none-view');
+      } else {
+        document.getElementById('adminLinks').classList.add('d-none-view');
+      }
+      persistSession();
+      updateFloorLink();
+      routeAfterLogin();
+    }
+    function updateFloorLink() {
+      const el = document.getElementById('link-floor');
+      if (!el) return;
+      const show = !!session.name && (session.isAdmin || ((session.tasks || []).length > 1));
+      el.classList.toggle('d-none-view', !show);
+    }
+    function routeAfterLogin() {
+      if (session.isAdmin) {
+        loadProductionOverview();
+        loadIdleWorkers();
+        return;
+      }
+      if (session.isQcOnly || (session.tasks && session.tasks.length === 1)) {
+        selectFloorTask(session.tasks[0] || 'Quality Control');
+        return;
+      }
+      showTaskPicker();
+    }
+    function goHome() {
+      if (!session.name) {
+        navTo('view-global-login');
+        return;
+      }
+      if (session.isAdmin) {
+        loadProductionOverview();
+        return;
+      }
+      if (session.tasks && session.tasks.length > 1) {
+        showTaskPicker();
+        return;
+      }
+      enterDashboard();
+    }
+    function showTaskPicker() {
+      const grid = document.getElementById('roleGrid');
+      const sub = document.getElementById('taskPickSubtitle');
+      const tasks = (session.isAdmin ? Object.keys(TASK_ICONS) : (session.tasks || [])).slice();
+      if (sub) {
+        sub.innerText = session.isAdmin
+          ? 'Admin — pick a floor task, or use Production in the menu.'
+          : ('Hi ' + session.name + '. What are you doing now?');
+      }
+      grid.innerHTML = '';
+      if (!tasks.length) {
+        grid.innerHTML = '<div class="col-12"><div class="card p-4">No tasks are assigned to you yet. Ask admin to add them on the Users sheet, column Tasks.</div></div>';
+      } else {
+        tasks.forEach(r => {
+          const icon = TASK_ICONS[r] || 'bi-gear';
+          grid.innerHTML += '<div class="col-12 col-sm-6 col-lg-4"><div class="card h-100 role-card task-card" onclick="selectFloorTask(\'' + r.replace(/'/g, "\\'") + '\')"><i class="bi ' + icon + '"></i><h4>' + r + '</h4></div></div>';
+        });
+      }
+      navTo('view-roles');
+    }
+    function selectFloorTask(r) {
+      session.role = r;
+      persistSession();
+      document.getElementById('adminLinks').classList.toggle('d-none-view', !session.isAdmin);
+      enterDashboard();
+    }
+
     function initApp() {
       // Fire both backend calls in parallel; hide loader after both return.
       let usersLoaded = false;
@@ -1532,11 +1751,23 @@
       function checkAllLoaded() {
         if (usersLoaded && profilesLoaded) {
           document.getElementById('loader').classList.add('d-none');
+          if (restoreSession()) {
+            setLoggedIn(true);
+            if (session.isAdmin) document.getElementById('adminLinks').classList.remove('d-none-view');
+            updateFloorLink();
+            if (session.isAdmin && !session.role) {
+              loadProductionOverview();
+              loadIdleWorkers();
+            } else if (session.role) {
+              enterDashboard();
+            } else {
+              routeAfterLogin();
+            }
+          }
         }
       }
       google.script.run.withSuccessHandler(data => {
         appData.users = data;
-        renderRoles();
         usersLoaded = true;
         checkAllLoaded();
       }).withFailureHandler(() => { usersLoaded = true; checkAllLoaded(); }).getUsersAndRoles();
@@ -1548,14 +1779,9 @@
       }).withFailureHandler(() => { profilesLoaded = true; checkAllLoaded(); }).getSteelProfiles();
     }
 
-    function renderRoles() {
-      const grid = document.getElementById('roleGrid'); grid.innerHTML = '';
-      [...new Set(appData.users.map(u => u.role))].sort().forEach(r => {
-        grid.innerHTML += `<div class="col-sm-6 col-md-4 col-lg-3"><div class="card p-4 text-center h-100 role-card" onclick="selectRole('${r}')"><h4>${r}</h4></div></div>`;
-      });
-    }
+    function renderRoles() { showTaskPicker(); }
 
-    function selectRole(r) { session.role = r; if(r.toLowerCase() === 'admin') promptPass('Admin'); else renderUsers(r); }
+    function selectRole(r) { selectFloorTask(r); }
     function renderUsers(r) {
       const list = document.getElementById('userList'); document.getElementById('selectedRoleTitle').innerText = r; list.innerHTML = '';
       appData.users.filter(u => u.role === r).forEach(u => list.innerHTML += `<button class="list-group-item list-group-item-action py-3 fw-bold" onclick="promptPass('${u.name}')">${u.name}</button>`);
@@ -1578,14 +1804,14 @@
       
       const btn = document.getElementById('btnGlobalLogin');
       const origText = btn.innerHTML;
-      btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span> UNLOCKING...';
+      btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span> LOGGING IN...';
       btn.disabled = true;
 
       google.script.run.withSuccessHandler(res => {
         btn.innerHTML = origText;
         btn.disabled = false;
         if(res.success) {
-          navTo('view-roles');
+          applyLoginProfile(res);
         } else {
           showAlert(res.error);
         }
@@ -1602,7 +1828,8 @@
         if(res.success) { 
           session.isAdmin = res.isAdmin; 
           if (passModal) passModal.hide(); 
-          if(session.role === 'Admin') {
+          persistSession();
+          if(session.role === 'Admin' || session.isAdmin) {
             document.getElementById('adminLinks').classList.remove('d-none-view');
             loadProductionOverview();
             loadIdleWorkers();
@@ -1615,8 +1842,11 @@
     }
     
     function logout() { 
-      session = { role: null, name: null, pendingRow: null, activeOrder: null, logId: null, logIds: {}, isAdmin: false, pendingBatchRows: null, pendingBatchMates: [] }; 
-      document.getElementById('adminLinks').classList.add('d-none-view'); 
+      session = { role: null, name: null, pendingRow: null, activeOrder: null, logId: null, logIds: {}, isAdmin: false, isQcOnly: false, tasks: [], jobTitle: '', pendingBatchRows: null, pendingBatchMates: [] }; 
+      clearPersistedSession();
+      setLoggedIn(false);
+      document.getElementById('adminLinks').classList.add('d-none-view');
+      updateFloorLink();
       document.getElementById('globalLoginName').value = '';
       document.getElementById('globalLoginPass').value = '';
       navTo('view-global-login'); 
@@ -1765,7 +1995,12 @@
     function enterDashboard() {
       navTo('view-dashboard');
       document.getElementById('dashUser').innerText = session.name;
-      document.getElementById('dashRole').innerText = session.role;
+      document.getElementById('dashRole').innerText = session.role || session.jobTitle || '';
+      const sw = document.getElementById('btnSwitchTask');
+      if (sw) {
+        const canSwitch = session.isAdmin || ((session.tasks || []).length > 1);
+        sw.classList.toggle('d-none', !canSwitch);
+      }
       const tabEl = document.querySelector('#dashTabs button[data-bs-target="#pane-available"]');
       if(tabEl) new bootstrap.Tab(tabEl).show();
       loadDashboard(false);

--- a/studio-delta-production/index.html
+++ b/studio-delta-production/index.html
@@ -1789,15 +1789,8 @@
     }
 
     function prefetchSupportData() {
-      google.script.run.withSuccessHandler(data => {
-        appData.users = data || [];
-      }).getUsersAndRoles();
-      google.script.run.withSuccessHandler(profiles => {
-        appData.steelProfiles = profiles || [];
-      }).getSteelProfiles();
-      google.script.run.withSuccessHandler(profiles => {
-        appData.backboards = profiles || [];
-      }).getBackboards();
+      // Steel, backboards, and users load on demand so login and the floor
+      // are not competing with extra spreadsheet reads.
     }
     function ensureSteelProfiles(cb) {
       if (appData.steelProfiles && appData.steelProfiles.length) {
@@ -2086,15 +2079,15 @@
     function loadDashboard(silent = false) {
       if (dashInFlight && silent) return;
       dashInFlight = true;
-      if(!silent) document.getElementById('container-available').innerHTML = '<div class="spinner-border"></div>';
-      if (session.name) {
-        google.script.run.withSuccessHandler(notice => {
-          if (notice && notice.resumedOrder) showSwitchBanner(notice);
-        }).popWorkerNotice(session.name);
+      const av = document.getElementById('container-available');
+      if (!silent && av && !av.querySelector('[id^="card-"]') && !av.querySelector('.checkbox-wrapper-16')) {
+        av.innerHTML = '<div class="spinner-border"></div>';
       }
-      google.script.run.withSuccessHandler(orders => {
+      google.script.run.withSuccessHandler(payload => {
         dashInFlight = false;
-        appData.currentOrders = orders; // Cache orders for the modal
+        const orders = (payload && payload.orders) ? payload.orders : (Array.isArray(payload) ? payload : []);
+        if (payload && payload.notice && payload.notice.resumedOrder) showSwitchBanner(payload.notice);
+        appData.currentOrders = orders;
         
         // 1. Only Siya can see the Powder Coating List Button
         const btnPowder = document.getElementById('btnPowderList');
@@ -2289,7 +2282,7 @@
         });
 
         filterDashboard(); 
-      }).withFailureHandler(() => { dashInFlight = false; }).getOrdersForRole(session.role, session.name);
+      }).withFailureHandler(() => { dashInFlight = false; }).pollFloor(session.role, session.name);
     }
     
     function continueToStartModal() {

--- a/studio-delta-production/index.html
+++ b/studio-delta-production/index.html
@@ -1695,6 +1695,8 @@
       'Welding': 'bi-lightning',
       'Grinding': 'bi-disc',
       'Quality Control': 'bi-clipboard-check',
+      'Paint Preparation': 'bi-brush',
+      'Painting': 'bi-palette',
       'Assembly': 'bi-box-seam'
     };
 
@@ -2177,7 +2179,7 @@
                }
              }
              else if(isLocked) innerBtn = `<button class="btn btn-secondary w-100 position-relative" style="z-index: 10;" disabled>LOCKED BY ${o.assigned}</button>`;
-             else innerBtn = `<button class="btn btn-primary w-100 position-relative" style="z-index: 10;" onclick="event.stopPropagation(); event.preventDefault(); preStart(${o.rowIndex}, '${o.order}')">START</button>`;
+             else innerBtn = availableStartButtons(o);
           }
           let btn = `<div class="action-btn-container w-100">${innerBtn}</div>`;
 
@@ -2285,8 +2287,29 @@
       }).withFailureHandler(() => { dashInFlight = false; }).pollFloor(session.role, session.name);
     }
     
+    function startTaskForOrder(o) {
+      const st = String(o && o.status || '').toLowerCase();
+      if (st === 'paint preparation') return 'Paint Preparation';
+      if (st === 'painting') return 'Painting';
+      if (st === 'assembly') return 'Assembly';
+      return session.role;
+    }
+
+    function availableStartButtons(o) {
+      const st = String(o.status || '').toLowerCase();
+      const start = (label, task, extraClass) =>
+        `<button class="btn ${extraClass || 'btn-primary'} flex-grow-1 position-relative" style="z-index: 10; flex-basis: 0;" onclick="event.stopPropagation(); event.preventDefault(); preStart(${o.rowIndex}, '${o.order}', '${task}')">${label}</button>`;
+      if (st === 'ready for assembly' && session.role === 'Assembly') {
+        return `<div class="d-flex gap-2 position-relative w-100 flex-wrap" style="z-index: 10;">${start('ASSEMBLE', 'Assembly', 'btn-primary')}${start('PAINT PREP', 'Paint Preparation', 'btn-outline-dark')}</div>`;
+      }
+      if (st === 'ready for assembly' && session.role === 'Paint Preparation') {
+        return start('START PAINT PREP', 'Paint Preparation');
+      }
+      return start('START', startTaskForOrder(o));
+    }
+
     function continueToStartModal() {
-      if (session.role === 'Assembly') {
+      if ((session.pendingStartTask || session.role) === 'Assembly') {
         document.getElementById('glassCheckOrder').innerText = session.activeOrder;
         if (glassCheckModal) glassCheckModal.show();
       } else {
@@ -2295,14 +2318,15 @@
       }
     }
 
-    function preStart(row, ord) { 
+    function preStart(row, ord, startTask) { 
       session.pendingRow = row; 
       session.activeOrder = ord;
+      session.pendingStartTask = startTask || startTaskForOrder((appData.currentOrders || []).find(o => o.rowIndex === row)) || session.role;
       session.pendingBatchRows = null;
       session.pendingBatchMates = [];
 
       const current = (appData.currentOrders || []).find(o => o.rowIndex === row);
-      if (session.role === 'Assembly' && current && current.productName) {
+      if ((session.pendingStartTask || session.role) === 'Assembly' && current && current.productName) {
         const mates = (appData.currentOrders || []).filter(o =>
           o.rowIndex !== row &&
           o.productName &&
@@ -2371,7 +2395,7 @@
            showAlert(res.message || res.error || "Could not start");
            loadDashboard();
         }
-      }).withFailureHandler(err => { isSubmitting=false; showAlert("Error: "+err); loadDashboard(); }).startOrder(session.pendingRow, session.name, session.role, session.pendingBatchRows);
+      }).withFailureHandler(err => { isSubmitting=false; showAlert("Error: "+err); loadDashboard(); }).startOrder(session.pendingRow, session.name, session.pendingStartTask || session.role, session.pendingBatchRows);
     }
 
     function prePause(row, ord) {
@@ -2478,7 +2502,7 @@
       
       // 3. EXCEPTIONS: GRINDING, POWDER COATING & DELIVERY (Skip Checklist)
       // Added "out for delivery" here so it skips the popup form
-      if(session.role === 'Grinding' || statusText === 'powder coating' || statusText === 'out for delivery') { 
+      if(session.role === 'Grinding' || statusText === 'powder coating' || statusText === 'out for delivery' || statusText === 'paint preparation' || statusText === 'painting') { 
         showConfirm("Finish " + (statusText || "Task") + "?", () => submitQC(true)); 
         return; 
       }

--- a/studio-delta-production/index.html
+++ b/studio-delta-production/index.html
@@ -3482,6 +3482,42 @@ function openSteelModal() {
       el.classList.add('active');
     }
 
+    function expandWorkerDaySlices(log) {
+      if (Array.isArray(log.daySlices) && log.daySlices.length) {
+        return log.daySlices.map(s => ({
+          order: log.order,
+          worker: log.worker,
+          task: log.task,
+          start: s.start,
+          end: s.stillRunning ? null : s.end,
+          durationMins: Number(s.durationMins) || 0,
+          week: s.week || log.week,
+          date: s.date,
+          stillRunning: !!s.stillRunning,
+          stopReason: s.stopReason || '',
+          pauseStart: (s.stillRunning && log.pauseStart && (!s.start || log.pauseStart >= s.start)) ? log.pauseStart : null,
+          pausedMins: 0
+        }));
+      }
+      const dur = (typeof log.durationMins === 'number')
+        ? log.durationMins
+        : calculateWorkMinutes(log.start, log.end, log.task, log.pausedMins, log.pauseStart);
+      return [{
+        order: log.order,
+        worker: log.worker,
+        task: log.task,
+        start: log.start,
+        end: log.end,
+        durationMins: dur,
+        week: log.week,
+        date: null,
+        stillRunning: !log.end,
+        stopReason: '',
+        pauseStart: log.pauseStart,
+        pausedMins: log.pausedMins
+      }];
+    }
+
     function loadWorkerStats() {
       navTo('view-admin-workers');
       loadIdleWorkers();
@@ -3520,8 +3556,8 @@ function openSteelModal() {
                           r.isChangeoverTracked = true;
                           r.changeoverMins = calculateWorkMinutes(maxEndBefore, r.start, 'Changeover');
                           
-                          // Safeguard: If gap >= 435 mins (full shift length), assume worker was absent.
-                          if (r.changeoverMins >= 435) {
+                          // Safeguard: If gap >= 450 mins (paid shift length), assume worker was absent.
+                          if (r.changeoverMins >= 450) {
                               r.changeoverMins = 0;
                               r.isChangeoverTracked = false;
                           }
@@ -3540,32 +3576,42 @@ function openSteelModal() {
            });
         });
 
-        // 3. Build Stats
+        // 3. Build Stats — overnight jobs count on each calendar day, matching Activity
         rawLogs.forEach(r => {
           if(!r.worker) return;
           if(!appData.workerStats[r.worker]) appData.workerStats[r.worker] = { totalMins: 0, weeks: {} };
-          const dur = calculateWorkMinutes(r.start, r.end, r.task, r.pausedMins, r.pauseStart);
-          appData.workerStats[r.worker].totalMins += dur;
-          r.durationMins = dur;
-          
-          // Group into weekly buckets
-          const weekKey = r.week || 'Unknown Week';
-          if(!appData.workerStats[r.worker].weeks[weekKey]) {
-            appData.workerStats[r.worker].weeks[weekKey] = { 
-              totalMins: 0, 
-              logs:[], 
-              uniqueOrders: new Set(),
-              totalChangeoverMins: 0,
-              changeoverCount: 0 
-            };
-          }
-          
-          appData.workerStats[r.worker].weeks[weekKey].totalMins += dur;
-          appData.workerStats[r.worker].weeks[weekKey].logs.push(r);
-          if(r.order) appData.workerStats[r.worker].weeks[weekKey].uniqueOrders.add(r.order);
-          
-          // Apply changeover stats (Even if it is 0, to reward efficiency)
+          const slices = expandWorkerDaySlices(r);
+          r.durationMins = slices.reduce((sum, s) => sum + (s.durationMins || 0), 0);
+
+          slices.forEach(slice => {
+            const dur = slice.durationMins || 0;
+            appData.workerStats[r.worker].totalMins += dur;
+            const weekKey = slice.week || r.week || 'Unknown Week';
+            if(!appData.workerStats[r.worker].weeks[weekKey]) {
+              appData.workerStats[r.worker].weeks[weekKey] = {
+                totalMins: 0,
+                logs:[],
+                uniqueOrders: new Set(),
+                totalChangeoverMins: 0,
+                changeoverCount: 0
+              };
+            }
+            appData.workerStats[r.worker].weeks[weekKey].totalMins += dur;
+            appData.workerStats[r.worker].weeks[weekKey].logs.push(slice);
+            if(r.order) appData.workerStats[r.worker].weeks[weekKey].uniqueOrders.add(r.order);
+          });
+
           if (r.isChangeoverTracked) {
+              const weekKey = (slices[0] && slices[0].week) || r.week || 'Unknown Week';
+              if(!appData.workerStats[r.worker].weeks[weekKey]) {
+                appData.workerStats[r.worker].weeks[weekKey] = {
+                  totalMins: 0,
+                  logs:[],
+                  uniqueOrders: new Set(),
+                  totalChangeoverMins: 0,
+                  changeoverCount: 0
+                };
+              }
               appData.workerStats[r.worker].weeks[weekKey].totalChangeoverMins += r.changeoverMins;
               appData.workerStats[r.worker].weeks[weekKey].changeoverCount += 1;
           }
@@ -3846,13 +3892,20 @@ function openSteelModal() {
 
       h += '<div class="modern-table-wrap"><table class="modern-table" id="workerLogTable"><thead><tr><th>Date</th><th>Order</th><th>Task</th><th>Start</th><th>End</th><th style="text-align:right">Duration</th></tr></thead><tbody>';
 
-      weekData.logs.sort((a, b) => b.start - a.start).forEach(l => {
-        const d = l.start ? new Date(l.start).toLocaleDateString() : '-';
+      weekData.logs.sort((a, b) => (b.start || 0) - (a.start || 0)).forEach(l => {
+        const d = l.date
+          ? new Date(l.date + 'T12:00:00').toLocaleDateString()
+          : (l.start ? new Date(l.start).toLocaleDateString() : '-');
         const s = l.start ? new Date(l.start).toLocaleTimeString([], {hour:'2-digit', minute:'2-digit', second:'2-digit'}) : '-';
-        const e = l.end ? new Date(l.end).toLocaleTimeString([], {hour:'2-digit', minute:'2-digit', second:'2-digit'}) : '<span class="badge bg-success">Running</span>';
+        const running = l.stillRunning || !l.end;
+        const e = running
+          ? '<span class="badge bg-success">Running</span>'
+          : new Date(l.end).toLocaleTimeString([], {hour:'2-digit', minute:'2-digit', second:'2-digit'});
         let durDisplay = formatDuration(l.durationMins);
-        if(!l.end) durDisplay = `<span class="badge bg-success live-timer" data-start="${l.start}" data-task="${l.task}" data-pmins="${l.pausedMins || 0}" data-pstart="${l.pauseStart || ''}">${durDisplay}</span>`;
-        h += `<tr data-order="${String(l.order).toLowerCase()}"><td>${d}</td><td><strong>${l.order}</strong></td><td>${l.task}</td><td>${s}</td><td>${e}</td><td style="text-align:right">${durDisplay}</td></tr>`;
+        if(running) {
+          durDisplay = `<span class="badge bg-success live-timer" data-start="${l.start}" data-task="${l.task}" data-pmins="${l.pausedMins || 0}" data-pstart="${l.pauseStart || ''}">${durDisplay}</span>`;
+        }
+        h += `<tr data-order="${String(l.order || '').toLowerCase()}"><td>${d}</td><td><strong>${l.order || ''}</strong></td><td>${l.task || ''}</td><td>${s}</td><td>${e}</td><td style="text-align:right">${durDisplay}</td></tr>`;
       });
 
       h += '</tbody></table></div>';

--- a/studio-delta-production/index.html
+++ b/studio-delta-production/index.html
@@ -1213,23 +1213,32 @@
   <div class="modal fade" id="alertModal" tabindex="-1"><div class="modal-dialog modal-dialog-centered"><div class="modal-content"><div class="modal-body text-center p-4"><h5 class="mb-3" id="alertMsg"></h5><button class="btn btn-primary px-4" data-bs-dismiss="modal">OK</button></div></div></div></div>
   <div class="modal fade" id="confirmModal" tabindex="-1"><div class="modal-dialog modal-dialog-centered"><div class="modal-content"><div class="modal-body text-center p-4"><h5 class="mb-3" id="confirmMsg"></h5><div class="d-flex justify-content-center gap-2"><button class="btn btn-primary px-4" id="confirmBtnYes">YES</button><button class="btn btn-outline-dark px-4" data-bs-dismiss="modal">NO</button></div></div></div></div></div>
 
-  <!-- NEW: Pause Modal -->
+  <!-- Pause / switch-reason modal -->
   <div class="modal fade" id="pauseModal" tabindex="-1">
     <div class="modal-dialog modal-dialog-centered">
       <div class="modal-content text-center p-4">
-        <h3 class="brand-font mb-2">Pause Order</h3>
+        <h3 class="brand-font mb-2" id="pauseModalTitle">Pause Order</h3>
+        <p class="text-muted mb-2" id="pauseModalHint">Every pause and every switch needs a reason.</p>
         <h1 class="fw-bold text-warning mb-3" id="pauseModalOrder">...</h1>
         <div class="mb-3 text-start">
-          <label class="form-label fw-bold">Reason for Pausing:</label>
-          <select id="pauseReasonSelect" class="form-select border-dark">
-            <option value="Waiting for plate">Waiting for plate</option>
-            <option value="Materials">Materials</option>
-            <option value="Other Product">Other Product</option>
-            <option value="Switched job">Switched job</option>
+          <label class="form-label fw-bold">Reason</label>
+          <select id="pauseReasonSelect" class="form-select border-dark" onchange="onPauseReasonChange()">
+            <option value="">Select a reason</option>
+            <option value="No materials">No materials</option>
+            <option value="Touch up">Touch up</option>
+            <option value="Other">Other</option>
           </select>
         </div>
+        <div class="mb-3 text-start d-none" id="pauseTouchUpWrap">
+          <label class="form-label fw-bold">Touch up — which order number?</label>
+          <input id="pauseTouchUpOrder" class="form-control border-dark" placeholder="e.g. 1042" autocomplete="off">
+        </div>
+        <div class="mb-3 text-start d-none" id="pauseOtherWrap">
+          <label class="form-label fw-bold">Please specify</label>
+          <input id="pauseOtherText" class="form-control border-dark" placeholder="Reason" autocomplete="off">
+        </div>
         <div class="d-flex justify-content-center gap-2 mt-3">
-          <button class="btn btn-warning px-4" onclick="confirmPause()">PAUSE NOW</button>
+          <button class="btn btn-warning px-4" id="pauseModalSubmit" onclick="submitPauseOrSwitchReason()">PAUSE NOW</button>
           <button class="btn btn-outline-dark px-4" data-bs-dismiss="modal">CANCEL</button>
         </div>
       </div>
@@ -1456,7 +1465,7 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <script>
     let appData = { users:[], workerStats: {}, currentOrders:[], steelProfiles:[], backboards:[] };
-    let session = { role: null, name: null, pendingRow: null, activeOrder: null, logId: null, logIds: {}, isAdmin: false, isQcOnly: false, tasks: [], jobTitle: '', pendingBatchRows: null, pendingBatchMates: [] };
+    let session = { role: null, name: null, pendingRow: null, activeOrder: null, logId: null, logIds: {}, isAdmin: false, isQcOnly: false, tasks: [], jobTitle: '', pendingBatchRows: null, pendingBatchMates: [], pendingStartTask: null, pendingSwitchReason: null, pauseModalMode: 'pause' };
     let idleAlertModal = null;
     let backboardSelectionModal = null;
     let idlePollTimer = null;
@@ -1899,7 +1908,7 @@
     }
     
     function logout() { 
-      session = { role: null, name: null, pendingRow: null, activeOrder: null, logId: null, logIds: {}, isAdmin: false, isQcOnly: false, tasks: [], jobTitle: '', pendingBatchRows: null, pendingBatchMates: [] }; 
+      session = { role: null, name: null, pendingRow: null, activeOrder: null, logId: null, logIds: {}, isAdmin: false, isQcOnly: false, tasks: [], jobTitle: '', pendingBatchRows: null, pendingBatchMates: [], pendingStartTask: null, pendingSwitchReason: null, pauseModalMode: 'pause' }; 
       clearPersistedSession();
       stopIdleAlertPolling();
       idleAlertDismissedKey = '';
@@ -1995,6 +2004,16 @@
                 isSubmitting = false;
                 btn.innerHTML = origText;
                 btn.disabled = false;
+                if (res && res.needsSwitchReason) {
+                  session.pendingRow = selected[0];
+                  session.pendingBatchRows = selected;
+                  openLeaveReasonModal('switch-start', res.runningOrders);
+                  return;
+                }
+                if (res && res.success === false) {
+                  showAlert(res.message || res.error || "Could not start");
+                }
+                session.pendingSwitchReason = null;
                 loadDashboard(true);
             })
             .withFailureHandler(err => {
@@ -2004,7 +2023,7 @@
                 showAlert("Error: " + err);
                 loadDashboard(true);
             })
-            .batchStartOrders(selected, session.name, session.role);
+            .batchStartOrders(selected, session.name, session.role, session.pendingSwitchReason);
     }
     
     function batchFinish() {
@@ -2373,7 +2392,8 @@
       const card = document.getElementById(`card-${session.pendingRow}`);
       if(card) {
         card.querySelector('.status-bar').className = 'status-bar bar-running';
-        card.querySelector('button').outerHTML = `<button class="btn btn-success w-100 position-relative" style="z-index: 10;" disabled>SYNCING...</button>`;
+        const firstBtn = card.querySelector('button');
+        if (firstBtn) firstBtn.outerHTML = `<button class="btn btn-success w-100 position-relative" style="z-index: 10;" disabled>SYNCING...</button>`;
         // Move the wrapper instead of just the card
         const wrapper = card.closest('.checkbox-wrapper-16') || card;
         document.getElementById('container-progress').appendChild(wrapper);
@@ -2390,27 +2410,98 @@
              session.logIds[session.activeOrder] = res.logId;
            }
            session.pendingBatchRows = null;
+           session.pendingSwitchReason = null;
            loadDashboard(true);
+        } else if (res.needsSwitchReason) {
+           loadDashboard(true);
+           openLeaveReasonModal('switch-start', res.runningOrders);
         } else {
            showAlert(res.message || res.error || "Could not start");
            loadDashboard();
         }
-      }).withFailureHandler(err => { isSubmitting=false; showAlert("Error: "+err); loadDashboard(); }).startOrder(session.pendingRow, session.name, session.pendingStartTask || session.role, session.pendingBatchRows);
+      }).withFailureHandler(err => { isSubmitting=false; showAlert("Error: "+err); loadDashboard(); }).startOrder(session.pendingRow, session.name, session.pendingStartTask || session.role, session.pendingBatchRows, session.pendingSwitchReason);
+    }
+
+    function onPauseReasonChange() {
+      const v = document.getElementById('pauseReasonSelect').value;
+      document.getElementById('pauseTouchUpWrap').classList.toggle('d-none', v !== 'Touch up');
+      document.getElementById('pauseOtherWrap').classList.toggle('d-none', v !== 'Other');
+    }
+
+    function resetPauseReasonForm() {
+      document.getElementById('pauseReasonSelect').value = '';
+      document.getElementById('pauseTouchUpOrder').value = '';
+      document.getElementById('pauseOtherText').value = '';
+      onPauseReasonChange();
+    }
+
+    function readPauseReasonForm() {
+      const kind = document.getElementById('pauseReasonSelect').value;
+      if (!kind) { showAlert('Choose a reason'); return null; }
+      if (kind === 'Touch up') {
+        const n = document.getElementById('pauseTouchUpOrder').value.trim();
+        if (!n) { showAlert('Enter the order number for the touch up'); return null; }
+        return 'Touch up #' + n.replace(/^#/, '');
+      }
+      if (kind === 'Other') {
+        const t = document.getElementById('pauseOtherText').value.trim();
+        if (!t) { showAlert('Enter the reason'); return null; }
+        return 'Other: ' + t;
+      }
+      return kind;
+    }
+
+    function openLeaveReasonModal(mode, runningOrders) {
+      session.pauseModalMode = mode || 'pause';
+      resetPauseReasonForm();
+      const title = document.getElementById('pauseModalTitle');
+      const hint = document.getElementById('pauseModalHint');
+      const orderEl = document.getElementById('pauseModalOrder');
+      const submit = document.getElementById('pauseModalSubmit');
+      if (session.pauseModalMode === 'pause') {
+        title.innerText = 'Pause Order';
+        hint.innerText = 'Why are you pausing this order?';
+        orderEl.innerText = session.activeOrder || '';
+        submit.innerText = 'PAUSE NOW';
+        submit.className = 'btn btn-warning px-4';
+      } else {
+        const names = (runningOrders || []).map(o => o.order).filter(Boolean).join(', ') || 'another order';
+        title.innerText = 'Leaving current order';
+        hint.innerText = 'You still have ' + names + ' running. Choose why you are switching.';
+        orderEl.innerText = session.activeOrder || '';
+        submit.innerText = 'CONTINUE';
+        submit.className = 'btn btn-primary px-4';
+      }
+      if (pauseModal) pauseModal.show();
+    }
+
+    function submitPauseOrSwitchReason() {
+      const reason = readPauseReasonForm();
+      if (!reason) return;
+      if (session.pauseModalMode === 'pause') {
+        confirmPause(reason);
+        return;
+      }
+      session.pendingSwitchReason = reason;
+      if (pauseModal) pauseModal.hide();
+      if (session.pauseModalMode === 'switch-resume') {
+        confirmResume(session.pendingRow, session.activeOrder);
+      } else {
+        confirmStart();
+      }
     }
 
     function prePause(row, ord) {
       session.pendingRow = row;
       session.activeOrder = ord;
-      document.getElementById('pauseModalOrder').innerText = ord;
-      if (pauseModal) pauseModal.show();
+      openLeaveReasonModal('pause');
     }
 
-    function confirmPause() {
+    function confirmPause(reason) {
       if (isSubmitting) return;
       isSubmitting = true;
       if (pauseModal) pauseModal.hide();
       
-      const reason = document.getElementById('pauseReasonSelect').value;
       const card = document.getElementById(`card-${session.pendingRow}`);
       if(card) {
         card.querySelector('.status-bar').className = 'status-bar bar-locked';
@@ -2445,13 +2536,18 @@
       google.script.run.withSuccessHandler(res => {
         isSubmitting = false;
         if(res.success) {
+           session.pendingSwitchReason = null;
            loadDashboard(true);
+        } else if (res.needsSwitchReason) {
+           loadDashboard(true);
+           openLeaveReasonModal('switch-resume', res.runningOrders);
         } else {
            showAlert(res.message);
            loadDashboard();
         }
-      }).withFailureHandler(err => { isSubmitting=false; showAlert("Error: "+err); loadDashboard(); }).workerResumeOrder(session.pendingRow, session.activeOrder, session.name);
+      }).withFailureHandler(err => { isSubmitting=false; showAlert("Error: "+err); loadDashboard(); }).workerResumeOrder(session.pendingRow, session.activeOrder, session.name, session.pendingSwitchReason);
     }
+
 
     function glassIsFine() {
       if (glassCheckModal) glassCheckModal.hide();
@@ -4856,11 +4952,12 @@ function openSteelModal() {
         });
         html += `</tbody></table></div>`;
         html += `<div class="small text-muted mb-1">What they did</div><ul class="mb-0">`;
-        (w.tasks || []).slice(0, 40).forEach(task => {
+        (w.tasks || []).slice(0, 80).forEach(task => {
           const kind = task.entryType === 'indirect' ? 'Non-order' : (task.order || '');
           const when = task.date ? ' · ' + task.date : '';
           const clock = task.start ? (' · ' + formatClock(task.start) + '–' + (task.end ? formatClock(task.end) : 'now')) : '';
-          html += `<li><strong>${task.task}</strong> · ${kind}${when}${clock} · ${formatDuration(task.minutes)}${task.end ? '' : ' (running)'}</li>`;
+          const pauseBit = task.stopReason ? `<div class="text-warning">Paused: ${task.stopReason}</div>` : '';
+          html += `<li><strong>${task.task}</strong> · ${kind}${when}${clock} · ${formatDuration(task.minutes)}${task.end ? '' : ' (running)'}${pauseBit}</li>`;
         });
         html += `</ul></div>`;
       });

--- a/studio-delta-production/index.html
+++ b/studio-delta-production/index.html
@@ -1341,6 +1341,64 @@
     </div>
   </div>
 
+  <!-- Backboard Selection Modal (Assembly / Final QC) -->
+  <div class="modal fade" id="backboardModal" tabindex="-1">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title brand-font">Select Backboard</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body p-3">
+          <div class="mb-3">
+            <label class="form-label fw-bold">1. Select Category</label>
+            <select id="backboardCategorySelect" class="form-select border-dark" onchange="onBackboardCategoryChange()">
+            </select>
+          </div>
+          <div class="mb-3">
+            <label class="form-label fw-bold">2. Select Backboard</label>
+            <select id="backboardProfileSelect" class="form-select border-dark" onchange="onBackboardProfileChange()">
+            </select>
+            <input type="text" id="backboardCustomProfile" class="form-control mt-2 d-none" placeholder="Enter custom backboard name">
+          </div>
+          <div class="mb-3">
+            <label class="form-label fw-bold">3. Size / Area</label>
+            <div class="d-flex gap-2">
+              <input type="number" id="backboardSizeInput" class="form-control border-dark" placeholder="E.g. 2.5" min="0" step="0.01">
+              <select id="backboardUnitSelect" class="form-select border-dark" style="width: 100px;">
+                <option value="m²">m²</option>
+                <option value="mm">mm</option>
+                <option value="sheet">sheet</option>
+              </select>
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">CANCEL</button>
+          <button type="button" class="btn btn-dark" onclick="addBackboardFromModal()">ADD BACKBOARD</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Idle workers popup for active Admin / QC -->
+  <div class="modal fade" id="idleAlertModal" tabindex="-1" data-bs-backdrop="static">
+    <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title brand-font">Idle workers</h5>
+        </div>
+        <div class="modal-body p-3">
+          <p class="text-muted small mb-3">These people have no running job during shift hours. Assign a task so they stay on the clock.</p>
+          <div id="idleAlertList"></div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-outline-secondary" onclick="dismissIdleAlertModal()">Later</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- Log Welder Steel Modal -->
   <div class="modal fade" id="welderSteelModal" tabindex="-1">
     <div class="modal-dialog modal-dialog-centered">
@@ -1397,8 +1455,12 @@
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <script>
-    let appData = { users:[], workerStats: {}, currentOrders:[], steelProfiles:[] };
+    let appData = { users:[], workerStats: {}, currentOrders:[], steelProfiles:[], backboards:[] };
     let session = { role: null, name: null, pendingRow: null, activeOrder: null, logId: null, logIds: {}, isAdmin: false, isQcOnly: false, tasks: [], jobTitle: '', pendingBatchRows: null, pendingBatchMates: [] };
+    let idleAlertModal = null;
+    let backboardSelectionModal = null;
+    let idlePollTimer = null;
+    let idleAlertDismissedKey = '';
     let activityChart = null;
     let batchWorkModal = null;
     let refreshInterval = null;
@@ -1538,6 +1600,8 @@
         confirmModal = new bootstrap.Modal('#confirmModal');
         weeklyDetailsModal = new bootstrap.Modal('#weeklyDetailsModal');
         steelSelectionModal = new bootstrap.Modal('#steelModal');
+        backboardSelectionModal = new bootstrap.Modal('#backboardModal');
+        idleAlertModal = new bootstrap.Modal('#idleAlertModal');
         welderSteelModal = new bootstrap.Modal('#welderSteelModal');
         batchWorkModal = new bootstrap.Modal('#batchWorkModal');
         
@@ -1635,34 +1699,13 @@
     };
 
     function persistSession() {
-      try {
-        localStorage.setItem('sd-session', JSON.stringify({
-          name: session.name,
-          role: session.role,
-          isAdmin: session.isAdmin,
-          isQcOnly: session.isQcOnly,
-          tasks: session.tasks || [],
-          jobTitle: session.jobTitle || ''
-        }));
-      } catch (e) {}
+      // Session is in-memory only. Every page load must show login first.
     }
     function clearPersistedSession() {
       try { localStorage.removeItem('sd-session'); } catch (e) {}
     }
     function restoreSession() {
-      try {
-        const raw = localStorage.getItem('sd-session');
-        if (!raw) return false;
-        const s = JSON.parse(raw);
-        if (!s || !s.name) return false;
-        session.name = s.name;
-        session.role = s.role || null;
-        session.isAdmin = !!s.isAdmin;
-        session.isQcOnly = !!s.isQcOnly;
-        session.tasks = s.tasks || [];
-        session.jobTitle = s.jobTitle || '';
-        return true;
-      } catch (e) { return false; }
+      return false;
     }
     function setLoggedIn(on) {
       document.body.classList.toggle('is-logged-in', !!on);
@@ -1682,6 +1725,7 @@
       }
       persistSession();
       updateFloorLink();
+      startIdleAlertPolling();
       routeAfterLogin();
     }
     function updateFloorLink() {
@@ -1751,6 +1795,9 @@
       google.script.run.withSuccessHandler(profiles => {
         appData.steelProfiles = profiles || [];
       }).getSteelProfiles();
+      google.script.run.withSuccessHandler(profiles => {
+        appData.backboards = profiles || [];
+      }).getBackboards();
     }
     function ensureSteelProfiles(cb) {
       if (appData.steelProfiles && appData.steelProfiles.length) {
@@ -1761,6 +1808,16 @@
         appData.steelProfiles = profiles || [];
         if (cb) cb();
       }).withFailureHandler(() => { if (cb) cb(); }).getSteelProfiles();
+    }
+    function ensureBackboards(cb) {
+      if (appData.backboards && appData.backboards.length) {
+        if (cb) cb();
+        return;
+      }
+      google.script.run.withSuccessHandler(profiles => {
+        appData.backboards = profiles || [];
+        if (cb) cb();
+      }).withFailureHandler(() => { if (cb) cb(); }).getBackboards();
     }
     function ensureUsers(cb) {
       if (appData.users && appData.users.length) {
@@ -1774,20 +1831,12 @@
     }
     function initApp() {
       document.getElementById('loader').classList.add('d-none');
+      clearPersistedSession();
       prefetchSupportData();
-      if (restoreSession()) {
-        setLoggedIn(true);
-        if (session.isAdmin) document.getElementById('adminLinks').classList.remove('d-none-view');
-        updateFloorLink();
-        if (session.isAdmin && !session.role) {
-          loadProductionOverview();
-          loadIdleWorkers();
-        } else if (session.role) {
-          enterDashboard();
-        } else {
-          routeAfterLogin();
-        }
-      }
+      setLoggedIn(false);
+      document.getElementById('adminLinks').classList.add('d-none-view');
+      updateFloorLink();
+      navTo('view-global-login');
     }
 
     function renderRoles() { showTaskPicker(); }
@@ -1840,6 +1889,8 @@
           session.isAdmin = res.isAdmin; 
           if (passModal) passModal.hide(); 
           persistSession();
+          setLoggedIn(true);
+          startIdleAlertPolling();
           if(session.role === 'Admin' || session.isAdmin) {
             document.getElementById('adminLinks').classList.remove('d-none-view');
             loadProductionOverview();
@@ -1855,6 +1906,9 @@
     function logout() { 
       session = { role: null, name: null, pendingRow: null, activeOrder: null, logId: null, logIds: {}, isAdmin: false, isQcOnly: false, tasks: [], jobTitle: '', pendingBatchRows: null, pendingBatchMates: [] }; 
       clearPersistedSession();
+      stopIdleAlertPolling();
+      idleAlertDismissedKey = '';
+      if (idleAlertModal) idleAlertModal.hide();
       setLoggedIn(false);
       document.getElementById('adminLinks').classList.add('d-none-view');
       updateFloorLink();
@@ -2459,6 +2513,20 @@
         document.getElementById('qcChecklistContainer').innerHTML += materialHtml;
       }
 
+      if (qcKey === 'Assembly' || qcKey === 'Final QC') {
+        const backboardHtml = `
+          <div id="backboardLoggingSection" class="mt-4 pt-3 border-top">
+            <div class="d-flex justify-content-between align-items-center mb-2">
+              <label class="fw-bold">Backboard Used <span class="text-danger">*</span></label>
+              <button type="button" class="btn btn-sm btn-outline-dark" onclick="openBackboardModal()">
+                <i class="bi bi-plus"></i> Select Backboard
+              </button>
+            </div>
+            <div id="backboardRowsContainer"></div>
+          </div>`;
+        document.getElementById('qcChecklistContainer').innerHTML += backboardHtml;
+      }
+
       document.getElementById('qcOrderNum').innerText = ord;
       
       // 5. PHOTO INPUTS
@@ -2588,6 +2656,108 @@ function openSteelModal() {
       container.appendChild(row);
 
       if (steelSelectionModal) steelSelectionModal.hide();
+    }
+
+    function openBackboardModal() {
+      ensureBackboards(() => openBackboardModalReady());
+    }
+    function openBackboardModalReady() {
+      document.getElementById('backboardSizeInput').value = '';
+      const customInput = document.getElementById('backboardCustomProfile');
+      customInput.value = '';
+      customInput.classList.add('d-none');
+
+      const categories = [...new Set((appData.backboards || []).map(p => p.category))];
+      if (!categories.includes("Custom")) categories.push("Custom");
+
+      const catSelect = document.getElementById('backboardCategorySelect');
+      catSelect.innerHTML = '<option value="">-- Choose Category --</option>' +
+        categories.map(c => `<option value="${c}">${c}</option>`).join('');
+
+      document.getElementById('backboardProfileSelect').innerHTML = '<option value="">-- Select Category First --</option>';
+
+      if (backboardSelectionModal) backboardSelectionModal.show();
+    }
+
+    function onBackboardCategoryChange() {
+      const cat = document.getElementById('backboardCategorySelect').value;
+      const profSelect = document.getElementById('backboardProfileSelect');
+      const customInput = document.getElementById('backboardCustomProfile');
+      customInput.classList.add('d-none');
+
+      if (!cat) {
+        profSelect.innerHTML = '<option value="">-- Select Category First --</option>';
+        return;
+      }
+
+      if (cat === 'Custom') {
+         profSelect.innerHTML = '<option value="__custom__">-- Enter Custom Backboard --</option>';
+         customInput.classList.remove('d-none');
+         return;
+      }
+
+      const profiles = (appData.backboards || []).filter(p => p.category === cat);
+      let html = '<option value="">-- Choose Backboard --</option>';
+      html += profiles.map(p => `<option value="${p.name}">${p.name}</option>`).join('');
+      html += '<option value="__custom__">+ Add Custom Backboard</option>';
+      profSelect.innerHTML = html;
+    }
+
+    function onBackboardProfileChange() {
+      const val = document.getElementById('backboardProfileSelect').value;
+      const customInput = document.getElementById('backboardCustomProfile');
+      if (val === '__custom__') {
+        customInput.classList.remove('d-none');
+        customInput.focus();
+      } else {
+        customInput.classList.add('d-none');
+      }
+    }
+
+    function addBackboardFromModal() {
+      const cat = document.getElementById('backboardCategorySelect').value;
+      const profVal = document.getElementById('backboardProfileSelect').value;
+      const customName = document.getElementById('backboardCustomProfile').value.trim();
+      const size = document.getElementById('backboardSizeInput').value.trim();
+      const unit = document.getElementById('backboardUnitSelect').value;
+
+      if (!cat || !profVal || !size) {
+        showAlert("Please select a category, backboard, and enter a size/area.");
+        return;
+      }
+
+      const isCustom = (profVal === '__custom__');
+      const finalName = isCustom ? customName : profVal;
+
+      if (isCustom && !finalName) {
+         showAlert("Please enter a custom backboard name.");
+         return;
+      }
+
+      const container = document.getElementById('backboardRowsContainer');
+      const rowId = 'brow-' + Date.now();
+      const fullSize = size + ' ' + unit;
+
+      const row = document.createElement('div');
+      row.className = 'backboard-row d-flex justify-content-between align-items-center mb-2 p-2 border rounded bg-light';
+      row.id = rowId;
+      row.dataset.category = cat;
+      row.dataset.name = finalName;
+      row.dataset.size = fullSize;
+      row.dataset.custom = isCustom;
+
+      row.innerHTML = `
+        <div>
+          <div class="fw-bold">${finalName}</div>
+          <div class="small text-muted">${cat} | ${fullSize}</div>
+        </div>
+        <button type="button" class="btn btn-sm btn-outline-danger" onclick="document.getElementById('${rowId}').remove()" title="Remove">
+          <i class="bi bi-trash"></i>
+        </button>
+      `;
+      container.appendChild(row);
+
+      if (backboardSelectionModal) backboardSelectionModal.hide();
     }
 
     function openWelderSteelModal() {
@@ -2741,7 +2911,7 @@ function openSteelModal() {
     async function submitQC(skip=false) {
       if(isSubmitting) return; // Prevent double clicks
       
-      let d = [], sig = '', fileData = [], dSteel = [];
+      let d = [], sig = '', fileData = [], dSteel = [], dBackboard = [];
       const card = document.getElementById(`card-${session.pendingRow}`);
 
       try {
@@ -2825,6 +2995,30 @@ function openSteelModal() {
                 showAlert("Invalid material row detected. Please check your entries."); return;
               }
             }
+
+            const backboardSection = document.getElementById('backboardLoggingSection');
+            if (backboardSection) {
+              const backboardRows = document.querySelectorAll('#backboardRowsContainer .backboard-row');
+              if (backboardRows.length === 0) {
+                showAlert("Please add at least one backboard used."); return;
+              }
+              let backboardValid = true;
+              backboardRows.forEach(rowEl => {
+                const type = rowEl.dataset.name;
+                const category = rowEl.dataset.category;
+                const size = rowEl.dataset.size;
+                const isCustom = rowEl.dataset.custom === 'true';
+
+                if (!type || !size) {
+                  backboardValid = false;
+                } else {
+                  dBackboard.push({ category: category, type: type, size: size, isCustom: isCustom });
+                }
+              });
+              if (!backboardValid) {
+                showAlert("Invalid backboard row detected. Please check your entries."); return;
+              }
+            }
           }
           
           // 4. UI FEEDBACK: SHOW LOADING STATE
@@ -2889,7 +3083,7 @@ function openSteelModal() {
               }
               loadDashboard(true);
             })
-            .finishOrder(session.pendingRow, (session.logIds && session.logIds[session.activeOrder]) || session.logId, d, sig, fileData, session.name, dSteel, session.activeOrder);
+            .finishOrder(session.pendingRow, (session.logIds && session.logIds[session.activeOrder]) || session.logId, d, sig, fileData, session.name, dSteel, session.activeOrder, dBackboard);
 
       } catch (err) {
           isSubmitting = false;
@@ -4462,28 +4656,97 @@ function openSteelModal() {
           box.innerHTML = '<span class="text-muted small">No idle workers right now.</span>';
           return;
         }
-        box.innerHTML = workers.map(w => {
-          const opts = tasks.map(task => '<option value="'+task+'">'+task+'</option>').join('');
-          const since = w.idleSince ? new Date(w.idleSince).toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'}) : 'unknown';
-          return `<div class="d-flex flex-wrap gap-2 align-items-center mb-2">
-            <strong>${w.worker}</strong>
-            <span class="badge bg-light text-dark border">${w.role}</span>
-            <span class="small text-muted">idle since ${since}</span>
-            <select class="form-select form-select-sm" style="max-width:220px" id="idle-task-${w.row}">${opts}</select>
-            <button class="btn btn-sm btn-dark" onclick="assignIdleTask('${w.worker}', ${w.row})">ASSIGN TASK</button>
-          </div>`;
-        }).join('');
+        box.innerHTML = workers.map(w => idleWorkerRowHtml(w, tasks, 'idle-task-')).join('');
       }).withFailureHandler(err => {
         box.innerHTML = '<span class="text-danger small">'+err+'</span>';
       }).getIdleWorkers();
     }
 
-    function assignIdleTask(worker, row) {
-      const sel = document.getElementById('idle-task-' + row);
+    function idleWorkerRowHtml(w, tasks, idPrefix) {
+      const opts = tasks.map(task => '<option value="'+task+'">'+task+'</option>').join('');
+      const since = w.idleSince ? new Date(w.idleSince).toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'}) : 'unknown';
+      const nameAttr = String(w.worker || '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/"/g,'&quot;');
+      const nameJs = JSON.stringify(String(w.worker || ''));
+      return `<div class="d-flex flex-wrap gap-2 align-items-center mb-2" data-idle-worker="${nameAttr}">
+            <strong>${nameAttr}</strong>
+            <span class="badge bg-light text-dark border">${w.role || ''}</span>
+            <span class="small text-muted">idle since ${since}</span>
+            <select class="form-select form-select-sm" style="max-width:220px" id="${idPrefix}${w.row}">${opts}</select>
+            <button class="btn btn-sm btn-dark" onclick="assignIdleTask(${nameJs}, ${w.row}, '${idPrefix}')">ASSIGN TASK</button>
+          </div>`;
+    }
+
+    function sessionSeesIdleAlerts() {
+      if (!session.name) return false;
+      if (session.isAdmin || session.isQcOnly) return true;
+      if (session.role === 'Quality Control') return true;
+      return (session.tasks || []).indexOf('Quality Control') !== -1;
+    }
+
+    function startIdleAlertPolling() {
+      stopIdleAlertPolling();
+      if (!sessionSeesIdleAlerts()) return;
+      pollIdleAlertsNow();
+      idlePollTimer = setInterval(() => {
+        if (document.hidden) return;
+        pollIdleAlertsNow();
+      }, 20000);
+    }
+
+    function stopIdleAlertPolling() {
+      if (idlePollTimer) clearInterval(idlePollTimer);
+      idlePollTimer = null;
+    }
+
+    function idleFingerprint(workers) {
+      return (workers || []).map(w => String(w.worker || '')).sort().join('|');
+    }
+
+    function pollIdleAlertsNow() {
+      if (!session.name || !sessionSeesIdleAlerts()) return;
+      google.script.run.withSuccessHandler(res => {
+        const workers = (res && res.alerts) || [];
+        const tasks = (res && res.tasks) || [];
+        const workersPage = document.getElementById('idleWorkersList');
+        if (workersPage && document.getElementById('view-admin-workers') && !document.getElementById('view-admin-workers').classList.contains('d-none-view')) {
+          loadIdleWorkers();
+        }
+        showIdleAlertPopup(workers, tasks);
+      }).withFailureHandler(() => {}).pollIdleAlerts(session.name);
+    }
+
+    function showIdleAlertPopup(workers, tasks) {
+      const box = document.getElementById('idleAlertList');
+      if (!box) return;
+      const key = idleFingerprint(workers);
+      if (!workers.length) {
+        idleAlertDismissedKey = '';
+        if (idleAlertModal) idleAlertModal.hide();
+        return;
+      }
+      if (key === idleAlertDismissedKey) return;
+      const idleEl = document.getElementById('idleAlertModal');
+      const alreadyOpen = idleEl && idleEl.classList.contains('show');
+      const otherModalOpen = !!document.querySelector('.modal.show') && !alreadyOpen;
+      if (otherModalOpen) return;
+      box.innerHTML = workers.map(w => idleWorkerRowHtml(w, tasks, 'idle-popup-task-')).join('');
+      if (idleAlertModal && !alreadyOpen) idleAlertModal.show();
+    }
+
+    function dismissIdleAlertModal() {
+      const names = Array.from(document.querySelectorAll('#idleAlertList [data-idle-worker]')).map(el => el.dataset.idleWorker);
+      idleAlertDismissedKey = names.sort().join('|');
+      if (idleAlertModal) idleAlertModal.hide();
+    }
+
+    function assignIdleTask(worker, row, idPrefix) {
+      const prefix = idPrefix || 'idle-task-';
+      const sel = document.getElementById(prefix + row);
       const task = sel ? sel.value : 'Other';
       google.script.run.withSuccessHandler(res => {
         if (!res.success) showAlert(res.message || 'Assign failed');
         loadIdleWorkers();
+        pollIdleAlertsNow();
       }).assignIndirectTask(worker, task, session.name);
     }
 

--- a/studio-delta-production/index.html
+++ b/studio-delta-production/index.html
@@ -1,0 +1,4366 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+  <base target="_top">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
+  <title>Studio Delta</title>
+  
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Outfit:wght@400;600;700&family=Playfair+Display:wght@400;600;700&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+  
+  <!-- Prevent flash of wrong theme on load -->
+  <script>
+    (function() {
+      var t = localStorage.getItem('sd-theme');
+      if (t === 'dark') document.documentElement.setAttribute('data-theme', 'dark');
+    })();
+  </script>
+
+  <style>
+    /* =====================================================
+       DESIGN TOKENS — LIGHT THEME (default)
+       ===================================================== */
+    :root {
+      --bg-page:       #f0f2f5;
+      --bg-surface:    #ffffff;
+      --bg-surface-2:  #f8f9fc;
+      --bg-sidebar:    #ffffff;
+      --border:        rgba(0,0,0,0.08);
+      --border-strong: rgba(0,0,0,0.18);
+      --text-primary:  #0f172a;
+      --text-secondary:#64748b;
+      --text-muted:    #94a3b8;
+      --accent:        #0f172a;
+      --accent-fg:     #ffffff;
+      --accent-hover:  #1e293b;
+      --success:       #10b981;
+      --success-fg:    #ffffff;
+      --warning:       #f59e0b;
+      --warning-fg:    #ffffff;
+      --danger:        #ef4444;
+      --shadow-sm:     0 1px 3px rgba(0,0,0,0.07), 0 1px 2px rgba(0,0,0,0.05);
+      --shadow-md:     0 4px 16px rgba(0,0,0,0.08), 0 2px 6px rgba(0,0,0,0.05);
+      --shadow-lg:     0 10px 40px rgba(0,0,0,0.12), 0 4px 12px rgba(0,0,0,0.07);
+      --radius-sm:     8px;
+      --radius-md:     14px;
+      --radius-lg:     20px;
+      --sidebar-width: 120px;
+      --transition:    0.2s cubic-bezier(0.4,0,0.2,1);
+    }
+
+    /* =====================================================
+       DESIGN TOKENS — DARK THEME
+       ===================================================== */
+    [data-theme="dark"] {
+      --bg-page:       #09090b;
+      --bg-surface:    #18181b;
+      --bg-surface-2:  #27272a;
+      --bg-sidebar:    #111113;
+      --border:        rgba(255,255,255,0.07);
+      --border-strong: rgba(255,255,255,0.15);
+      --text-primary:  #f4f4f5;
+      --text-secondary:#a1a1aa;
+      --text-muted:    #71717a;
+      --accent:        #e4e4e7;
+      --accent-fg:     #09090b;
+      --accent-hover:  #ffffff;
+      --success:       #10b981;
+      --warning:       #f59e0b;
+      --danger:        #f87171;
+      --shadow-sm:     0 1px 3px rgba(0,0,0,0.4);
+      --shadow-md:     0 4px 16px rgba(0,0,0,0.5);
+      --shadow-lg:     0 10px 40px rgba(0,0,0,0.7);
+    }
+
+    /* =====================================================
+       BASE
+       ===================================================== */
+    *, *::before, *::after { box-sizing: border-box; }
+
+    body {
+      background-color: var(--bg-page);
+      color: var(--text-primary);
+      font-family: 'Inter', sans-serif;
+      overflow-x: hidden;
+      transition: background-color 0.3s ease, color 0.3s ease;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    h1, h2, h3, h4, h5, .brand-font {
+      font-family: 'Playfair Display', serif;
+      color: var(--text-primary);
+      letter-spacing: -0.01em;
+    }
+
+    a { color: inherit; }
+
+    /* =====================================================
+       SIDEBAR
+       ===================================================== */
+    .sidebar {
+      position: fixed;
+      top: 0; left: 0;
+      height: 100vh;
+      width: var(--sidebar-width);
+      background: var(--bg-sidebar);
+      z-index: 1000;
+      box-shadow: var(--shadow-md);
+      border-right: 1px solid var(--border);
+      padding: 16px 8px;
+      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+      transition: background-color 0.3s ease, box-shadow 0.3s ease, left 0.3s ease;
+    }
+
+    .sidebar-header { margin-bottom: 18px; text-align: center; }
+    .sidebar-header h5 {
+      font-size: 0.8rem;
+      font-family: 'Outfit', sans-serif;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      color: var(--text-primary);
+    }
+
+    .sidebar-link {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 12px 8px;
+      margin-bottom: 4px;
+      color: var(--text-secondary);
+      text-decoration: none;
+      font-weight: 500;
+      cursor: pointer;
+      border-radius: var(--radius-sm);
+      transition: all var(--transition);
+      border: 1px solid transparent;
+    }
+    .sidebar-link i { font-size: 1.6rem; margin-bottom: 5px; }
+    .sidebar-link .link-text { font-size: 0.7rem; text-align: center; line-height: 1.2; font-weight: 600; letter-spacing: 0.02em; }
+    .sidebar-link:hover {
+      background-color: var(--bg-surface-2);
+      color: var(--text-primary);
+      border-color: var(--border);
+      transform: translateY(-1px);
+    }
+    .sidebar-link.active {
+      background: var(--bg-surface-2);
+      color: var(--text-primary);
+      border-color: var(--border-strong);
+      box-shadow: var(--shadow-sm);
+    }
+
+    .sidebar-footer { margin-top: auto; padding-top: 16px; display: flex; flex-direction: column; gap: 8px; }
+    .sidebar-footer .btn { font-size: 0.7rem; padding: 0.45rem; }
+
+    /* Theme toggle button in sidebar */
+    .theme-toggle-btn {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 4px;
+      padding: 10px 8px;
+      background: var(--bg-surface-2);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+      cursor: pointer;
+      color: var(--text-secondary);
+      font-size: 0.7rem;
+      font-weight: 600;
+      letter-spacing: 0.02em;
+      transition: all var(--transition);
+      width: 100%;
+    }
+    .theme-toggle-btn i { font-size: 1.2rem; }
+    .theme-toggle-btn:hover {
+      background: var(--bg-surface);
+      color: var(--text-primary);
+      border-color: var(--border-strong);
+    }
+
+    /* =====================================================
+       MAIN CONTENT
+       ===================================================== */
+    .main-content { margin-left: var(--sidebar-width); }
+    .main-content .container-fluid { padding: 36px 1.5rem 4rem; }
+
+    /* =====================================================
+       CARDS
+       ===================================================== */
+    .card {
+      border: 1px solid var(--border);
+      border-radius: var(--radius-md);
+      background-color: var(--bg-surface);
+      box-shadow: var(--shadow-sm);
+      transition: box-shadow var(--transition), transform var(--transition), background-color 0.3s ease, border-color 0.3s ease;
+    }
+    .card:hover { box-shadow: var(--shadow-md); }
+    .role-card:hover { transform: translateY(-3px); box-shadow: var(--shadow-md); }
+    .role-card:active { transform: scale(0.98); }
+    .card-body { padding: 1.1rem 1.25rem; }
+
+    /* =====================================================
+       BUTTONS
+       ===================================================== */
+    .btn {
+      font-family: 'Inter', sans-serif;
+      font-weight: 600;
+      font-size: 0.875rem;
+      letter-spacing: 0.02em;
+      border-radius: var(--radius-sm);
+      transition: all var(--transition);
+    }
+    .btn:active { transform: scale(0.97); }
+
+    .btn-primary, .btn-primary:hover, .btn-primary:active, .btn-primary:focus {
+      background-color: var(--accent) !important;
+      border-color: var(--accent) !important;
+      color: var(--accent-fg) !important;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.2) !important;
+    }
+    .btn-primary:hover {
+      background-color: var(--accent-hover) !important;
+      box-shadow: 0 4px 14px rgba(0,0,0,0.25) !important;
+      transform: translateY(-1px);
+    }
+
+    .btn-success, .btn-success:hover, .btn-success:active, .btn-success:focus {
+      background-color: var(--success) !important;
+      border-color: var(--success) !important;
+      color: var(--success-fg) !important;
+    }
+    .btn-success:hover { filter: brightness(1.1); transform: translateY(-1px); }
+
+    .btn-warning, .btn-warning:hover, .btn-warning:active, .btn-warning:focus {
+      background-color: var(--warning) !important;
+      border-color: var(--warning) !important;
+      color: var(--warning-fg) !important;
+    }
+    .btn-warning:hover { filter: brightness(1.08); transform: translateY(-1px); }
+
+    .btn-outline-dark, .btn-outline-dark:hover {
+      border-color: var(--border-strong) !important;
+      color: var(--text-primary) !important;
+      background: transparent;
+    }
+    .btn-outline-dark:hover {
+      background: var(--bg-surface-2) !important;
+    }
+
+    .btn-outline-danger { border-color: var(--danger) !important; color: var(--danger) !important; }
+    .btn-outline-danger:hover { background: var(--danger) !important; color: #fff !important; }
+
+    .btn-secondary, .btn-secondary:hover, .btn-secondary:focus {
+      background-color: var(--bg-surface-2) !important;
+      border-color: var(--border) !important;
+      color: var(--text-secondary) !important;
+    }
+
+    .btn-dark, .btn-dark:hover {
+      background-color: var(--accent) !important;
+      border-color: var(--accent) !important;
+      color: var(--accent-fg) !important;
+    }
+
+    .btn-link { color: var(--text-muted) !important; }
+    .btn-link:hover { color: var(--text-primary) !important; }
+
+    /* =====================================================
+       NAVIGATION PILLS
+       ===================================================== */
+    .nav-pills {
+      background: var(--bg-surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-md);
+      padding: 6px;
+      box-shadow: var(--shadow-sm);
+    }
+    .nav-pills .nav-link {
+      color: var(--text-secondary) !important;
+      font-weight: 600;
+      border-radius: var(--radius-sm);
+      transition: all var(--transition);
+      font-size: 0.875rem;
+    }
+    .nav-pills .nav-link.active {
+      background-color: var(--accent) !important;
+      color: var(--accent-fg) !important;
+      box-shadow: var(--shadow-sm);
+    }
+    .nav-pills .nav-link:hover:not(.active) {
+      background: var(--bg-surface-2);
+      color: var(--text-primary) !important;
+    }
+
+    /* =====================================================
+       FORMS
+       ===================================================== */
+    .form-control, .form-select {
+      background-color: var(--bg-surface);
+      border: 1px solid var(--border-strong);
+      border-radius: var(--radius-sm);
+      color: var(--text-primary);
+      font-family: 'Inter', sans-serif;
+      font-size: 0.9rem;
+      transition: border-color var(--transition), box-shadow var(--transition), background-color 0.3s ease;
+    }
+    .form-control:focus, .form-select:focus {
+      background-color: var(--bg-surface);
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px rgba(15,23,42,0.1);
+      color: var(--text-primary);
+    }
+    [data-theme="dark"] .form-control:focus,
+    [data-theme="dark"] .form-select:focus {
+      box-shadow: 0 0 0 3px rgba(228,228,231,0.15);
+    }
+    .form-control::placeholder { color: var(--text-muted); }
+    .form-label { color: var(--text-secondary); font-weight: 600; font-size: 0.85rem; }
+
+    /* =====================================================
+       STATUS BAR ON TASK CARDS
+       ===================================================== */
+    .status-bar { height: 3px; width: 100%; border-radius: var(--radius-md) var(--radius-md) 0 0; }
+    .bar-ready   { background: linear-gradient(90deg, var(--accent), var(--accent)); }
+    .bar-running { background: linear-gradient(90deg, #10b981, #34d399); }
+    .bar-locked  { background: linear-gradient(90deg, #f59e0b, #fbbf24); }
+
+    /* =====================================================
+       BADGES
+       ===================================================== */
+    .badge {
+      font-family: 'Inter', sans-serif;
+      font-weight: 600;
+      font-size: 0.7rem;
+      border-radius: 6px;
+      letter-spacing: 0.03em;
+    }
+    .badge.bg-dark {
+      background-color: var(--bg-surface-2) !important;
+      color: var(--text-secondary) !important;
+      border: 1px solid var(--border);
+    }
+
+    /* =====================================================
+       TABLES
+       ===================================================== */
+    .table {
+      color: var(--text-primary);
+      border-color: var(--border);
+    }
+    .table-dark { background-color: var(--accent); }
+    .table > :not(caption) > * > * { background-color: transparent; }
+    .table-hover > tbody > tr:hover > * { background-color: var(--bg-surface-2); }
+    .table-bordered > :not(caption) > * > * { border-color: var(--border); }
+
+    /* =====================================================
+       MODALS
+       ===================================================== */
+    .modal-content {
+      background-color: var(--bg-surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-lg);
+      color: var(--text-primary);
+      box-shadow: var(--shadow-lg);
+    }
+    .modal-header {
+      border-bottom-color: var(--border);
+      padding: 1.25rem 1.5rem;
+    }
+    .modal-footer {
+      border-top-color: var(--border);
+      padding: 1rem 1.5rem;
+    }
+    .modal-body { padding: 1.5rem; }
+    .btn-close { filter: var(--bs-btn-close-white-filter, none); }
+    [data-theme="dark"] .btn-close { filter: invert(1) grayscale(1); }
+
+    /* =====================================================
+       LOADER
+       ===================================================== */
+    #loader { background-color: var(--bg-surface); transition: background-color 0.3s ease; }
+
+    /* =====================================================
+       MISC UTILITY
+       ===================================================== */
+    .d-none-view { display: none !important; }
+    #sigCanvas {
+      border: 1px solid var(--border-strong);
+      border-radius: var(--radius-sm);
+      width: 100%; height: 200px;
+      touch-action: none;
+      background-color: #fff;
+    }
+    .live-timer { font-variant-numeric: tabular-nums; font-family: 'Inter', sans-serif; font-weight: 600; }
+    .text-muted { color: var(--text-muted) !important; }
+
+    /* =====================================================
+       ANIMATIONS
+       ===================================================== */
+    @keyframes slideIn {
+      from { opacity: 0; transform: translateY(12px); }
+      to   { opacity: 1; transform: translateY(0); }
+    }
+    .animate-card { animation: slideIn 0.28s cubic-bezier(0.4,0,0.2,1) forwards; }
+
+    /* =====================================================
+       MOBILE MENU BUTTON
+       ===================================================== */
+    .mobile-menu-btn {
+      position: fixed;
+      top: 15px; left: 15px;
+      z-index: 1100;
+      width: 44px; height: 44px;
+      background: var(--accent);
+      border: none;
+      border-radius: var(--radius-sm);
+      display: none;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      box-shadow: var(--shadow-md);
+      transition: all var(--transition);
+    }
+    .mobile-menu-btn:hover { filter: brightness(1.15); transform: translateY(-1px); }
+    .mobile-menu-btn:active { transform: translateY(0); }
+    .mobile-menu-btn i { font-size: 1.5rem; color: var(--accent-fg); }
+
+    /* Mobile backdrop overlay */
+    .mobile-backdrop {
+      display: none;
+      position: fixed; top:0; left:0; width:100%; height:100%;
+      background: rgba(0,0,0,0.55);
+      backdrop-filter: blur(4px);
+      z-index: 999;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.3s ease;
+    }
+    .mobile-backdrop.show { opacity: 1; pointer-events: auto; }
+
+    /* =====================================================
+       RESPONSIVE — MOBILE
+       ===================================================== */
+    @media (max-width: 768px) {
+      .mobile-menu-btn { display: flex; }
+      .mobile-backdrop { display: block; }
+      .container-fluid { padding-left: 12px !important; padding-right: 12px !important; padding-top: 68px !important; }
+      h1.display-4 { font-size: 2rem; }
+      h2 { font-size: 1.5rem; }
+      h3 { font-size: 1.25rem; }
+      h4 { font-size: 1.1rem; }
+      .sidebar { width: 280px; left: -280px; box-shadow: var(--shadow-lg); }
+      .sidebar.mobile-open { left: 0; }
+      .sidebar-link { padding: 14px 12px; }
+      .sidebar-link i { font-size: 1.7rem; }
+      .sidebar-link .link-text { font-size: 0.8rem; }
+      .main-content { margin-left: 0; }
+      .card { margin-bottom: 1rem; }
+      .card-body { padding: 1rem; }
+      .btn { padding: 0.7rem 1rem; font-size: 0.9rem; min-height: 44px; }
+      .btn-sm { min-height: 36px; }
+      .nav-pills { flex-direction: column; }
+      .nav-pills .nav-link { margin-bottom: 0.4rem; text-align: center; }
+      .form-control { font-size: 16px; padding: 0.7rem; min-height: 44px; }
+      .modal-dialog { margin: 0.5rem; }
+      .table { font-size: 0.82rem; }
+      #sigCanvas { height: 150px; }
+      #adminProdTabs { flex-wrap: wrap; }
+      #adminProdTabs .nav-link { font-size: 0.82rem; padding: 0.5rem; }
+    }
+
+    @media (min-width: 576px) and (max-width: 991px) {
+      .container { max-width: 100%; padding: 0 15px; }
+      h1.display-4 { font-size: 2.5rem; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .sidebar, .animate-card { animation: none; transition: none; }
+    }
+
+    /* =====================================================
+       STICKY TABLE COLUMNS
+       ===================================================== */
+    .sticky-col {
+      position: sticky; left: 0;
+      background-color: var(--bg-surface);
+      z-index: 10; min-width: 100px;
+    }
+    .sticky-col-2 {
+      position: sticky; left: 100px;
+      background-color: var(--bg-surface);
+      z-index: 10; min-width: 150px;
+    }
+    .table-dark .sticky-col, .table-dark .sticky-col-2 { background-color: #212529; }
+
+    /* =====================================================
+       BATCH CHECKBOX TILE
+       ===================================================== */
+    .checkbox-wrapper-16 { display: block; width: 100%; margin-bottom: 1rem; }
+    .checkbox-wrapper-16 .checkbox-input {
+      clip: rect(0 0 0 0); -webkit-clip-path: inset(100%); clip-path: inset(100%);
+      height: 1px; overflow: hidden; position: absolute; white-space: nowrap; width: 1px;
+    }
+    .checkbox-wrapper-16 .checkbox-input:checked + .checkbox-tile {
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px rgba(15,23,42,0.12), var(--shadow-md);
+    }
+    [data-theme="dark"] .checkbox-wrapper-16 .checkbox-input:checked + .checkbox-tile {
+      box-shadow: 0 0 0 3px rgba(228,228,231,0.18), var(--shadow-md);
+    }
+    .checkbox-wrapper-16 .checkbox-input:checked + .checkbox-tile .custom-check-circle {
+      transform: scale(1); opacity: 1;
+      background-color: var(--accent); border-color: var(--accent);
+    }
+    .checkbox-wrapper-16 .checkbox-tile {
+      display: block; border: 2px solid transparent;
+      border-radius: var(--radius-md);
+      background-color: var(--bg-surface);
+      box-shadow: var(--shadow-sm);
+      transition: all var(--transition);
+      cursor: pointer; position: relative; margin: 0; height: 100%;
+    }
+    .checkbox-wrapper-16 .checkbox-tile:hover {
+      border-color: var(--accent); transform: translateY(-3px); box-shadow: var(--shadow-md);
+    }
+    .checkbox-wrapper-16 .checkbox-tile:hover .custom-check-circle { opacity: 1; border-color: var(--accent); }
+    .custom-check-circle {
+      display: inline-flex; width: 1.4rem; height: 1.4rem;
+      border: 2px solid var(--border-strong); background-color: var(--bg-surface);
+      border-radius: 50%; opacity: 0.5; transition: 0.2s ease;
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='192' height='192' fill='%23FFFFFF' viewBox='0 0 256 256'%3E%3Crect width='256' height='256' fill='none'%3E%3C/rect%3E%3Cpolyline points='216 72.005 104 184 48 128.005' fill='none' stroke='%23FFFFFF' stroke-linecap='round' stroke-linejoin='round' stroke-width='32'%3E%3C/polyline%3E%3C/svg%3E");
+      background-size: 12px; background-repeat: no-repeat; background-position: 50% 50%;
+      margin-right: 12px; flex-shrink: 0;
+    }
+
+    /* =====================================================
+       WORKER TAB — PREMIUM UI COMPONENTS
+       ===================================================== */
+    .worker-card {
+      display: flex; align-items: center; gap: 12px; width: 100%;
+      padding: 12px 14px; background: var(--bg-surface);
+      border: none; border-left: 3px solid transparent;
+      border-bottom: 1px solid var(--border);
+      text-align: left; cursor: pointer;
+      transition: all var(--transition); color: var(--text-primary);
+      font-family: 'Inter', sans-serif;
+    }
+    .worker-card:hover { background: var(--bg-surface-2); border-left-color: var(--text-secondary); transform: translateX(2px); }
+    .worker-card.active { background: var(--bg-surface-2); border-left-color: var(--accent); font-weight: 700; }
+    .worker-card .worker-name { flex: 1; font-size: 0.92rem; }
+    .worker-card .worker-hours {
+      font-size: 0.78rem; font-weight: 700; color: var(--text-secondary);
+      background: var(--bg-surface-2); border: 1px solid var(--border);
+      border-radius: 20px; padding: 2px 10px; white-space: nowrap;
+    }
+
+    /* Avatar circle */
+    .avatar-circle {
+      width: 38px; height: 38px; border-radius: 50%;
+      background: var(--accent); color: var(--accent-fg);
+      display: flex; align-items: center; justify-content: center;
+      font-size: 1rem; font-weight: 700; flex-shrink: 0;
+      font-family: 'Playfair Display', serif;
+    }
+    .avatar-circle.lg { width: 54px; height: 54px; font-size: 1.4rem; }
+
+    /* Stat card */
+    .stat-card {
+      background: var(--bg-surface); border-radius: var(--radius-md);
+      padding: 18px 16px; text-align: center;
+      box-shadow: var(--shadow-sm); border: 1px solid var(--border);
+      transition: box-shadow var(--transition), transform var(--transition), background-color 0.3s;
+    }
+    .stat-card:hover { box-shadow: var(--shadow-md); transform: translateY(-3px); }
+    .stat-card .stat-icon { font-size: 1.5rem; margin-bottom: 6px; display: block; }
+    .stat-card .stat-label {
+      font-size: 0.68rem; font-weight: 700; text-transform: uppercase;
+      letter-spacing: 0.07em; color: var(--text-muted); margin-bottom: 4px;
+    }
+    .stat-card .stat-value {
+      font-size: 1.6rem; font-weight: 700;
+      font-family: 'Playfair Display', serif; line-height: 1;
+      color: var(--text-primary);
+    }
+    .stat-card.success .stat-icon, .stat-card.success .stat-value { color: var(--success); }
+
+    /* Modern table */
+    .modern-table { width: 100%; border-collapse: collapse; font-size: 0.875rem; }
+    .modern-table thead th {
+      background: var(--accent); color: var(--accent-fg);
+      font-size: 0.7rem; font-weight: 700; text-transform: uppercase;
+      letter-spacing: 0.06em; padding: 10px 12px; border: none;
+      position: sticky; top: 0; z-index: 2;
+    }
+    .modern-table tbody tr { border-bottom: 1px solid var(--border); transition: background 0.15s ease; }
+    .modern-table tbody tr:hover { background: var(--bg-surface-2); }
+    .modern-table tbody td { padding: 9px 12px; vertical-align: middle; border: none; color: var(--text-primary); }
+    .modern-table-wrap {
+      border-radius: var(--radius-md); overflow: hidden;
+      box-shadow: var(--shadow-sm); border: 1px solid var(--border);
+      max-height: 420px; overflow-y: auto;
+    }
+
+    /* Batch action container */
+    #batchActionContainer {
+      background: var(--bg-surface) !important;
+      border-color: var(--border-strong) !important;
+      border-radius: var(--radius-md) !important;
+      color: var(--text-primary) !important;
+    }
+    #batchCount { color: var(--text-primary) !important; }
+
+    /* Dropdown menus */
+    .dropdown-menu {
+      background: var(--bg-surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-md);
+      box-shadow: var(--shadow-lg);
+      color: var(--text-primary);
+    }
+    .dropdown-item { color: var(--text-primary); }
+    .dropdown-item:hover { background: var(--bg-surface-2); color: var(--text-primary); }
+
+    /* List groups */
+    .list-group { border-radius: var(--radius-md); overflow: hidden; }
+    .list-group-item {
+      background: var(--bg-surface);
+      border-color: var(--border);
+      color: var(--text-primary);
+    }
+
+    /* Spinner */
+    .spinner-border { color: var(--accent) !important; }
+
+    /* Bg-white / bg-light utility overrides */
+    .bg-white { background-color: var(--bg-surface) !important; }
+    .bg-light { background-color: var(--bg-surface-2) !important; }
+    .shadow-sm { box-shadow: var(--shadow-sm) !important; }
+    .shadow { box-shadow: var(--shadow-md) !important; }
+    .border { border-color: var(--border) !important; }
+    .border-dark { border-color: var(--border-strong) !important; }
+
+    /* Input group & search highlight */
+    .form-control:focus { outline: none; }
+
+    /* Rounded containers in admin tabs */
+    #workerDetailContent, #orderOverviewContainer, #weeklyCompletionsContainer,
+    .bg-white.p-4.rounded, .bg-white.rounded {
+      background-color: var(--bg-surface) !important;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-md) !important;
+    }
+
+    /* Headings in view sections */
+    .view-section > h2, .view-section > .brand-font { margin-bottom: 1.25rem; }
+
+    /* Page section cards for Chart.js canvases */
+    .bg-white.rounded.shadow-sm.p-4,
+    .bg-white.p-4.rounded.shadow-sm {
+      background-color: var(--bg-surface) !important;
+      border: 1px solid var(--border) !important;
+    }
+
+    .floor-banner {
+      display: none;
+      margin: 0 0 16px;
+      padding: 14px 16px;
+      border-radius: var(--radius-md);
+      border: 1px solid var(--border-strong);
+      background: var(--bg-surface);
+      box-shadow: var(--shadow-sm);
+    }
+    .floor-banner.show { display: flex; gap: 12px; align-items: center; justify-content: space-between; flex-wrap: wrap; }
+    .badge-batch { background: #0f172a; color: #fff; }
+    [data-theme="dark"] .badge-batch { background: #e4e4e7; color: #09090b; }
+    .ot-badge { background: #f59e0b; color: #111; }
+    .over-limit-row { background: rgba(245, 158, 11, 0.12); }
+    .idle-card { border: 1px dashed var(--border-strong); }
+    .product-sub { font-size: 0.75rem; color: var(--text-secondary); font-weight: 500; }
+    .hours-regular { font-variant-numeric: tabular-nums; }
+  </style>
+</head>
+<body>
+
+  <div id="loader" class="position-fixed top-0 start-0 w-100 h-100 bg-white d-flex flex-column justify-content-center align-items-center" style="z-index:9999;">
+    <h2 class="brand-font mb-3">STUDIO DELTA</h2>
+    <div class="spinner-border text-dark"></div>
+  </div>
+
+  <!-- Mobile Menu Button -->
+  <button class="mobile-menu-btn" id="mobileMenuBtn" aria-label="Toggle menu">
+    <i class="bi bi-list"></i>
+  </button>
+
+  <!-- Mobile Backdrop -->
+  <div class="mobile-backdrop" id="mobileBackdrop"></div>
+
+  <nav class="sidebar" id="sidebar" aria-label="Main navigation">
+    <div class="sidebar-header">
+      <h5 class="brand-font mb-0">STUDIO DELTA</h5>
+    </div>
+    <a id="link-roles" class="sidebar-link active" onclick="navTo('view-roles')">
+      <i class="bi bi-house-door"></i>
+      <span class="link-text">Home</span>
+    </a>
+    <div id="adminLinks" class="d-none-view">
+      <a id="link-prod" class="sidebar-link" onclick="loadProductionOverview()">
+        <i class="bi bi-clipboard-data"></i>
+        <span class="link-text">Production</span>
+      </a>
+      <a id="link-work" class="sidebar-link" onclick="loadWorkerStats()">
+        <i class="bi bi-people"></i>
+        <span class="link-text">Workers</span>
+      </a>
+      <a id="link-metrics" class="sidebar-link" onclick="loadMetricsDashboard()">
+        <i class="bi bi-bar-chart"></i>
+        <span class="link-text">Metrics</span>
+      </a>
+      <a id="link-reports" class="sidebar-link" onclick="loadQCReports()">
+        <i class="bi bi-file-earmark-pdf"></i>
+        <span class="link-text">QC Reports</span>
+      </a>
+      <a id="link-activity" class="sidebar-link" onclick="loadActivityReport()">
+        <i class="bi bi-calendar3"></i>
+        <span class="link-text">Activity</span>
+      </a>
+    </div>
+    <div class="sidebar-footer">
+      <button class="theme-toggle-btn" id="themeToggleBtn" onclick="toggleTheme()" title="Toggle Light/Dark Mode">
+        <i class="bi bi-moon-stars-fill" id="themeToggleIcon"></i>
+        <span id="themeToggleLabel">Dark</span>
+      </button>
+      <button class="btn btn-outline-danger w-100 btn-sm" onclick="logout()">Log Out</button>
+    </div>
+  </nav>
+
+  <div class="main-content" id="mainContent">
+  <div class="container-fluid">
+    
+    <div id="view-global-login" class="view-section container">
+      <div class="text-center mb-5 mt-5">
+        <h1 class="display-4 fw-bold">Studio Delta</h1>
+        <p class="text-muted small text-uppercase">Production Management System</p>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-md-6 col-lg-4">
+          <div class="card p-4 shadow-sm animate-card">
+            <h4 class="mb-4 text-center">App Login</h4>
+            <div class="mb-3">
+              <label class="form-label">Name</label>
+              <input type="text" id="globalLoginName" class="form-control" placeholder="Enter your name">
+            </div>
+            <div class="mb-4">
+              <label class="form-label">Password</label>
+              <input type="password" id="globalLoginPass" class="form-control" placeholder="Enter access code">
+            </div>
+            <button id="btnGlobalLogin" class="btn btn-primary w-100 py-2 fw-bold" onclick="submitGlobalLogin()">UNLOCK APP</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div id="view-roles" class="view-section container d-none-view">
+      <div class="text-center mb-5"><h1 class="display-4 fw-bold">Studio Delta</h1><p class="text-muted small text-uppercase">Production Management System</p></div>
+      <div class="row g-3" id="roleGrid"></div>
+    </div>
+
+    <div id="view-users" class="view-section container d-none-view">
+      <button class="btn btn-outline-dark mb-4" onclick="navTo('view-roles')">&larr; BACK</button>
+      <h2 class="mb-4"><span id="selectedRoleTitle"></span> Team</h2>
+      <div class="list-group list-group-flush bg-white rounded shadow-sm" id="userList"></div>
+    </div>
+
+    <div id="view-dashboard" class="view-section container d-none-view">
+      <div id="switchBanner" class="floor-banner">
+        <div>
+          <strong id="switchBannerTitle">Plate ready</strong>
+          <div class="small text-muted" id="switchBannerMsg"></div>
+        </div>
+        <div class="d-flex gap-2">
+          <button class="btn btn-sm btn-outline-dark" onclick="dismissSwitchBanner()">OK</button>
+          <button class="btn btn-sm btn-warning" id="btnStillOnOther" onclick="undoSwitch()">STILL ON OTHER JOB</button>
+        </div>
+      </div>
+      <div class="d-flex justify-content-between align-items-center mb-4 border-bottom pb-2">
+        <div><h4 class="m-0" id="dashUser">User</h4><small class="text-muted text-uppercase" id="dashRole">Role</small></div>
+      </div>
+      
+      <div class="row mb-3">
+        <div class="col-md-6 mb-2 mb-md-0">
+          <input type="text" id="dashSearch" class="form-control" placeholder="Search Order #" onkeyup="filterDashboard()">
+        </div>
+        <div class="col-md-6 d-none" id="qcPhaseFilterContainer">
+          <select id="qcPhaseFilter" class="form-select border-dark" onchange="filterDashboard()">
+            <option value="">All Production Phases</option>
+          </select>
+        </div>
+      </div>
+
+      <div id="batchActionContainer" class="mb-3 d-none p-2 bg-light border border-2 border-dark rounded d-flex justify-content-between align-items-center">
+        <span id="batchCount" class="fw-bold text-primary">0 Selected</span>
+        <div>
+            <button id="btnBatchStart" class="btn btn-sm btn-primary d-none fw-bold px-3" onclick="batchStart()">START SELECTED</button>
+            <button id="btnBatchFinish" class="btn btn-sm btn-success d-none fw-bold px-3" onclick="batchFinish()">FINISH SELECTED</button>
+        </div>
+      </div>
+
+      <ul class="nav nav-pills nav-fill mb-4 bg-white p-2 rounded shadow-sm" id="dashTabs">
+        <li class="nav-item"><button class="nav-link active" data-bs-toggle="pill" data-bs-target="#pane-available">Available</button></li>
+        <li class="nav-item"><button class="nav-link" data-bs-toggle="pill" data-bs-target="#pane-progress">In Progress</button></li>
+      </ul>
+      
+      <div class="d-flex justify-content-between align-items-center mb-3">
+        <div class="d-flex flex-wrap gap-2">
+          <button id="btnPowderList" class="btn btn-sm btn-dark d-none" onclick="openPowderModal()">
+            <i class="bi bi-list-check"></i> Powder Coating List
+          </button>
+          <button id="btnLogWelderSteel" class="btn btn-sm btn-dark d-none" onclick="openWelderSteelModal()">
+            <i class="bi bi-box-seam"></i> Log Welder Steel
+          </button>
+        </div>
+        <div class="text-end flex-grow-1">
+          <button class="btn btn-sm btn-link text-muted text-decoration-none" onclick="loadDashboard()">
+            <i class="bi bi-arrow-clockwise"></i> Refresh
+          </button>
+        </div>
+      </div>
+      
+      <div class="tab-content">
+        <div class="tab-pane fade show active" id="pane-available"><div id="container-available"></div></div>
+        <div class="tab-pane fade" id="pane-progress"><div id="container-progress"></div></div>
+      </div>
+    </div>
+
+    <div id="view-admin-prod" class="view-section container d-none-view">
+      <h2 class="brand-font mb-4">Production Overview</h2>
+      
+      <input type="text" id="prodSearch" class="form-control mb-3" placeholder="Search Order #" onkeyup="filterProduction()">
+
+      <ul class="nav nav-pills mb-3" id="adminProdTabs">
+        <li class="nav-item"><button class="nav-link active" data-bs-toggle="pill" data-bs-target="#tab-notstarted">Not Started</button></li>
+        <li class="nav-item"><button class="nav-link" data-bs-toggle="pill" data-bs-target="#tab-production">In Production</button></li>
+        <li class="nav-item"><button class="nav-link" data-bs-toggle="pill" data-bs-target="#tab-delivery">Out for Delivery</button></li>
+      </ul>
+      <div class="tab-content">
+        <div class="tab-pane fade show active" id="tab-notstarted"><div id="list-notstarted"></div></div>
+        <div class="tab-pane fade" id="tab-production"><div id="list-production"></div></div>
+        <div class="tab-pane fade" id="tab-delivery"><div id="list-delivery"></div></div>
+      </div>
+    </div>
+
+    <div id="view-admin-workers" class="view-section container d-none-view">
+      <div id="idleWorkersPanel" class="card p-3 mb-4 idle-card">
+        <div class="d-flex justify-content-between align-items-center mb-2">
+          <h5 class="brand-font m-0">Idle workers</h5>
+          <button class="btn btn-sm btn-outline-dark" onclick="loadIdleWorkers()"><i class="bi bi-arrow-clockwise"></i></button>
+        </div>
+        <p class="small text-muted mb-2">During shift hours, workers with no running job appear here. Assign a non-order task; it closes automatically when they start an order.</p>
+        <div id="idleWorkersList"><span class="text-muted small">Loading…</span></div>
+      </div>
+      <h2 class="brand-font mb-3">Worker Information</h2>
+
+      <!-- Sub-tabs -->
+      <ul class="nav nav-pills mb-4" id="workerSubTabs">
+        <li class="nav-item">
+          <button class="nav-link active" data-bs-toggle="pill" data-bs-target="#worker-individual">Individual Stats</button>
+        </li>
+        <li class="nav-item">
+          <button class="nav-link" data-bs-toggle="pill" data-bs-target="#worker-comparison">Weekly Comparison</button>
+        </li>
+      </ul>
+
+      <div class="tab-content">
+        <!-- Individual Stats Pane -->
+        <div class="tab-pane fade show active" id="worker-individual">
+          <div class="row">
+            <div class="col-md-4 mb-3"><div class="list-group" id="workerSelect_List"></div></div>
+            <div class="col-md-8"><div id="workerDetailContent" class="bg-white p-4 rounded shadow-sm"><p class="text-muted text-center">Select a worker.</p></div></div>
+          </div>
+        </div>
+
+        <!-- Weekly Comparison Pane -->
+        <div class="tab-pane fade" id="worker-comparison">
+          <div class="row g-2 mb-4">
+            <!-- Week Dropdown -->
+            <div class="col-md-4">
+              <label class="form-label small fw-bold text-uppercase text-muted mb-1">Select Week</label>
+              <select id="globalCompareWeekFilter" class="form-select" onchange="renderWorkerComparison()">
+                <option value="">-- Load workers first --</option>
+              </select>
+            </div>
+            <!-- Worker Filter Dropdown -->
+            <div class="col-md-5">
+              <label class="form-label small fw-bold text-uppercase text-muted mb-1">Filter Workers</label>
+              <div class="dropdown">
+                <button class="btn btn-outline-dark dropdown-toggle w-100 text-start d-flex justify-content-between align-items-center shadow-sm"
+                  type="button" data-bs-toggle="dropdown" data-bs-auto-close="outside" id="compareWorkerFilterBtn" disabled>
+                  <span>Load workers first</span>
+                </button>
+                <ul class="dropdown-menu w-100 p-2 shadow" id="compareWorkerFilterList" style="max-height: 250px; overflow-y: auto;">
+                  <li><span class="text-muted small px-2">Load workers first.</span></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+          <div class="bg-white p-4 rounded shadow-sm mb-4">
+            <canvas id="workerComparisonChart" style="max-height: 400px;"></canvas>
+          </div>
+          <div id="workerComparisonTableContainer"></div>
+        </div>
+      </div>
+    </div>
+
+    <div id="view-admin-metrics" class="view-section container d-none-view">
+      <h2 class="brand-font mb-4">Metrics Dashboard</h2>
+      
+      <!-- Sub-tabs for Metrics -->
+      <ul class="nav nav-pills mb-3" id="metricsTabs">
+        <li class="nav-item">
+          <button class="nav-link active" data-bs-toggle="pill" data-bs-target="#tab-order-overview">Order Overview</button>
+        </li>
+        <li class="nav-item">
+          <button class="nav-link" data-bs-toggle="pill" data-bs-target="#tab-production-trends">Production Trends</button>
+        </li>
+        <li class="nav-item">
+          <button class="nav-link" data-bs-toggle="pill" data-bs-target="#tab-weekly-completions">Weekly Completions</button>
+        </li>
+      </ul>
+      
+      <div class="tab-content">
+        <!-- Order Overview Tab -->
+        <div class="tab-pane fade show active" id="tab-order-overview">
+          <div class="row mb-3 align-items-end">
+            <!-- Week Dropdown -->
+            <div class="col-md-3 mb-2">
+              <label for="overviewWeekFilter" class="form-label small text-muted mb-1 fw-bold">Filter by Week:</label>
+              <select id="overviewWeekFilter" class="form-select border-dark shadow-sm" onchange="filterOrderMetrics()">
+                <option value="">All Weeks</option>
+              </select>
+            </div>
+            <!-- Product Name Filter -->
+            <div class="col-md-3 mb-2">
+              <label for="overviewProductFilter" class="form-label small text-muted mb-1 fw-bold">Filter by Product:</label>
+              <select id="overviewProductFilter" class="form-select border-dark shadow-sm" onchange="filterOrderMetrics()">
+                <option value="">All Products</option>
+              </select>
+            </div>
+            <!-- Search Bar -->
+            <div class="col-md-4 mb-2">
+              <label for="orderSearch" class="form-label small text-muted mb-1 fw-bold">Search Order:</label>
+              <input type="text" id="orderSearch" class="form-control border-dark shadow-sm" placeholder="Search Order #" onkeyup="filterOrderMetrics()">
+            </div>
+            <!-- Refresh Button -->
+            <div class="col-md-2 text-md-end mb-2">
+              <button class="btn btn-sm btn-link text-muted text-decoration-none" onclick="loadOrderOverview()">
+                <i class="bi bi-arrow-clockwise"></i> Refresh
+              </button>
+            </div>
+          </div>
+          <div id="orderOverviewContainer" class="bg-white rounded shadow-sm">
+            <div class="text-center p-5">
+              <div class="spinner-border"></div>
+            </div>
+          </div>
+        </div>
+        
+        <!-- Production Trends Tab -->
+        <div class="tab-pane fade" id="tab-production-trends">
+          <div class="row mb-3 align-items-end">
+            <!-- NEW: Week Dropdown -->
+            <div class="col-md-3 mb-2">
+              <label for="trendWeekFilter" class="form-label small text-muted mb-1 fw-bold">Filter by Week:</label>
+              <select id="trendWeekFilter" class="form-select border-dark shadow-sm" onchange="filterProductionTrends()">
+                <option value="">All Weeks</option>
+              </select>
+            </div>
+            <!-- Product Dropdown -->
+            <div class="col-md-3 mb-2">
+              <label for="productFilter" class="form-label small text-muted mb-1 fw-bold">Filter by Product:</label>
+              <select id="productFilter" class="form-select border-dark shadow-sm" onchange="filterProductionTrends()">
+                <option value="">All Products</option>
+              </select>
+            </div>
+            <!-- Order Checkboxes Dropdown -->
+            <div class="col-md-4 mb-2">
+              <label class="form-label small text-muted mb-1 fw-bold">Specific Orders:</label>
+              <div class="dropdown">
+                <!-- data-bs-auto-close="outside" keeps the menu open while checking multiple boxes -->
+                <button class="btn btn-outline-dark dropdown-toggle w-100 text-start d-flex justify-content-between align-items-center shadow-sm" type="button" data-bs-toggle="dropdown" data-bs-auto-close="outside" id="orderFilterBtn" disabled>
+                  <span>Select Product First</span>
+                </button>
+                <ul class="dropdown-menu w-100 p-2 shadow" id="orderFilterList" style="max-height: 250px; overflow-y: auto;">
+                  <li><span class="text-muted small px-2">Select a product to view orders.</span></li>
+                </ul>
+              </div>
+            </div>
+            <!-- Refresh Button -->
+            <div class="col-md-2 text-md-end mb-2">
+              <button class="btn btn-sm btn-link text-muted text-decoration-none" onclick="loadProductionTrends()">
+                <i class="bi bi-arrow-clockwise"></i> Refresh
+              </button>
+            </div>
+          </div>
+          
+          <!-- MISSING CANVAS RESTORED HERE -->
+          <div class="bg-white rounded shadow-sm p-4">
+            <canvas id="productionTrendsChart" style="max-height: 500px;"></canvas>
+          </div>
+        </div>
+        
+        <!-- NEW: Weekly Completions Tab -->
+        <div class="tab-pane fade" id="tab-weekly-completions">
+          <div class="text-end mb-2">
+            <button class="btn btn-sm btn-link text-muted text-decoration-none" onclick="loadWeeklyCompletions()">
+              <i class="bi bi-arrow-clockwise"></i> Refresh
+            </button>
+          </div>
+          <div id="weeklyCompletionsContainer" class="bg-white rounded shadow-sm">
+            <div class="text-center p-5">
+              <div class="spinner-border"></div>
+            </div>
+          </div>
+        </div>
+
+      </div> 
+    </div>
+    
+    <div id="view-admin-activity" class="view-section container d-none-view">
+      <h2 class="brand-font mb-3">Employee Activity</h2>
+      <p class="text-muted">A standard day is 8 hours. Time beyond that is overtime.</p>
+      <div class="row g-2 mb-3">
+        <div class="col-md-3">
+          <select id="activityPeriod" class="form-select border-dark" onchange="loadActivityReport()">
+            <option value="day">Daily</option>
+            <option value="week">Weekly</option>
+            <option value="month">Monthly</option>
+          </select>
+        </div>
+        <div class="col-md-3">
+          <input type="date" id="activityDate" class="form-control border-dark" onchange="loadActivityReport()">
+        </div>
+        <div class="col-md-3">
+          <select id="activityWorker" class="form-select border-dark" onchange="loadActivityReport()">
+            <option value="">All workers</option>
+          </select>
+        </div>
+        <div class="col-md-3">
+          <button class="btn btn-dark w-100" onclick="loadActivityReport()"><i class="bi bi-arrow-clockwise"></i> Refresh</button>
+        </div>
+      </div>
+      <div class="row g-3 mb-3">
+        <div class="col-md-4"><div class="card p-3"><div class="text-muted small">REGULAR (capped 8h/day)</div><div class="fs-4 hours-regular" id="activityRegular">00:00</div></div></div>
+        <div class="col-md-4"><div class="card p-3"><div class="text-muted small">OVERTIME</div><div class="fs-4 text-warning" id="activityOt">00:00</div></div></div>
+        <div class="col-md-4"><div class="card p-3"><div class="text-muted small">DAYS OVER 8 HOURS</div><div class="fs-4" id="activityOverDays">0</div></div></div>
+      </div>
+      <div class="bg-white rounded shadow-sm p-3 mb-3">
+        <canvas id="activityChart" style="max-height: 320px;"></canvas>
+      </div>
+      <div id="activityTable" class="bg-white rounded shadow-sm"></div>
+    </div>
+
+    <div id="view-admin-qc-reports" class="view-section container d-none-view">
+      <h2 class="brand-font mb-4">Saved QC Reports</h2>
+      
+      <div class="row mb-3">
+        <div class="col-md-8 mb-2">
+          <input type="text" id="qcReportSearch" class="form-control border-dark shadow-sm" placeholder="Search by Order # or Type..." onkeyup="renderQCReports()">
+        </div>
+        <div class="col-md-4 text-md-end mb-2">
+          <button class="btn btn-dark shadow-sm w-100" onclick="loadQCReports()">
+            <i class="bi bi-arrow-clockwise"></i> Refresh List
+          </button>
+        </div>
+      </div>
+
+      <div class="bg-white p-2 rounded shadow-sm border" style="max-height: 70vh; overflow-y: auto;">
+        <div id="qcReportsContainer">
+          <!-- Populated by JS -->
+        </div>
+      </div>
+    </div>
+
+  </div>
+  </div>
+
+  <div class="modal fade" id="passModal" tabindex="-1"><div class="modal-dialog modal-dialog-centered"><div class="modal-content text-center p-4"><h3 class="mb-3">Access Code</h3><p class="text-muted" id="passPromptName">Enter code</p><input type="password" id="inputPass" class="form-control text-center mb-3"><button class="btn btn-primary w-100" onclick="submitPass()">ENTER</button></div></div></div>
+  <div class="modal fade" id="startModal" tabindex="-1"><div class="modal-dialog modal-dialog-centered"><div class="modal-content text-center p-4"><h3 class="brand-font mb-2">Start Order</h3><h1 class="fw-bold text-primary mb-3" id="startModalOrder">...</h1><button class="btn btn-primary btn-lg w-100 mt-3" onclick="confirmStart()">START TIMER</button></div></div></div>
+  <div class="modal fade" id="batchWorkModal" tabindex="-1">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content p-4 text-center">
+        <h3 class="brand-font mb-2">Same product</h3>
+        <p class="mb-3" id="batchWorkMsg">These orders need the same work. Work them together?</p>
+        <div id="batchWorkList" class="text-start mb-3 small"></div>
+        <p class="small text-muted">Together = one clock, time split. Only this order = pause any other running job.</p>
+        <div class="d-grid gap-2">
+          <button class="btn btn-dark" onclick="confirmBatchTogether()">WORK TOGETHER</button>
+          <button class="btn btn-outline-dark" onclick="confirmBatchOnlyThis()">ONLY THIS ORDER</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="modal fade" id="qcModal" tabindex="-1"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><h5 class="modal-title brand-font">Checklist</h5><button class="btn-close" data-bs-dismiss="modal"></button></div><div class="modal-body p-4">
+    <div class="mb-3"><strong>Order:</strong> <span id="qcOrderNum"></span></div>
+    <div id="qcChecklistContainer"></div>
+    
+    <div id="qcPhotoContainer" class="mt-3 d-none">
+      <label class="fw-bold mb-2">Required Photos</label>
+      <div id="qcPhotoInputs"></div>
+    </div>
+
+    <div class="mt-4"><label class="fw-bold">Signature</label><div class="border"><canvas id="sigCanvas"></canvas></div><button class="btn btn-sm btn-outline-secondary mt-2" onclick="clearSignature()">Clear</button></div>
+  </div><div class="modal-footer"><button class="btn btn-primary" onclick="submitQC()">CONFIRM</button></div></div></div></div>
+  <div class="modal fade" id="alertModal" tabindex="-1"><div class="modal-dialog modal-dialog-centered"><div class="modal-content"><div class="modal-body text-center p-4"><h5 class="mb-3" id="alertMsg"></h5><button class="btn btn-primary px-4" data-bs-dismiss="modal">OK</button></div></div></div></div>
+  <div class="modal fade" id="confirmModal" tabindex="-1"><div class="modal-dialog modal-dialog-centered"><div class="modal-content"><div class="modal-body text-center p-4"><h5 class="mb-3" id="confirmMsg"></h5><div class="d-flex justify-content-center gap-2"><button class="btn btn-primary px-4" id="confirmBtnYes">YES</button><button class="btn btn-outline-dark px-4" data-bs-dismiss="modal">NO</button></div></div></div></div></div>
+
+  <!-- NEW: Pause Modal -->
+  <div class="modal fade" id="pauseModal" tabindex="-1">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content text-center p-4">
+        <h3 class="brand-font mb-2">Pause Order</h3>
+        <h1 class="fw-bold text-warning mb-3" id="pauseModalOrder">...</h1>
+        <div class="mb-3 text-start">
+          <label class="form-label fw-bold">Reason for Pausing:</label>
+          <select id="pauseReasonSelect" class="form-select border-dark">
+            <option value="Waiting for plate">Waiting for plate</option>
+            <option value="Materials">Materials</option>
+            <option value="Other Product">Other Product</option>
+            <option value="Switched job">Switched job</option>
+          </select>
+        </div>
+        <div class="d-flex justify-content-center gap-2 mt-3">
+          <button class="btn btn-warning px-4" onclick="confirmPause()">PAUSE NOW</button>
+          <button class="btn btn-outline-dark px-4" data-bs-dismiss="modal">CANCEL</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- NEW: Glass Check Modal for Assembly -->
+  <div class="modal fade" id="glassCheckModal" tabindex="-1"><div class="modal-dialog modal-dialog-centered"><div class="modal-content"><div class="modal-body text-center p-4"><h3 class="brand-font mb-2">Glass Check</h3><h5 class="fw-bold mb-3" id="glassCheckOrder"></h5><p>Have you checked the glass for scratches?</p><div class="d-flex justify-content-center gap-2"><button class="btn btn-success px-4" onclick="document.getElementById('startModalOrder').innerText=session.activeOrder; if(glassCheckModal)glassCheckModal.hide(); if(startModal)startModal.show();">YES</button><button class="btn btn-danger px-4" onclick="if(glassCheckModal)glassCheckModal.hide(); showAlert('Cannot start without checking glass.');">NO</button></div></div></div></div></div>
+
+  <!-- NEW: Powder Coating List Modal -->
+  <div class="modal fade" id="powderModal" tabindex="-1">
+    <div class="modal-dialog modal-xl modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title brand-font">Powder Coating List</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body p-3">
+          <div class="table-responsive">
+            <table class="table table-bordered table-hover align-middle mb-0" style="font-size: 0.85rem;">
+              <thead class="table-dark text-center">
+                <tr>
+                  <th style="width: 5%;">Send</th>
+                  <th style="width: 12%;">Order #</th>
+                  <th style="width: 25%;">Item Description</th>
+                  <th style="width: 18%;">Dimensions (mm)</th>
+                  <th style="width: 8%;">QTY</th>
+                  <th style="width: 12%;">Colour</th>
+                  <th style="width: 20%;">Profiles Used</th>
+                </tr>
+              </thead>
+              <tbody id="powderTableBody">
+                <!-- Dynamic rows generated via JS -->
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">CANCEL</button>
+          <button type="button" class="btn btn-primary" onclick="submitPowderList()">SEND LIST</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- NEW: Weekly Details Modal -->
+  <div class="modal fade" id="weeklyDetailsModal" tabindex="-1">
+    <div class="modal-dialog modal-dialog-centered modal-lg">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title brand-font" id="weeklyDetailsTitle">Details</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body p-3">
+          <div class="table-responsive">
+            <table class="table table-hover table-sm mb-0">
+              <thead class="table-dark">
+                <tr><th>Order #</th><th>Product Name</th><th>Worker</th></tr>
+              </thead>
+              <tbody id="weeklyDetailsBody">
+                <!-- Populated via JS -->
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- NEW: Steel Selection Modal -->
+  <div class="modal fade" id="steelModal" tabindex="-1">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title brand-font">Select Steel Profile</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body p-3">
+          <div class="mb-3">
+            <label class="form-label fw-bold">1. Select Category</label>
+            <select id="steelCategorySelect" class="form-select border-dark" onchange="onSteelCategoryChange()">
+              <!-- Populated dynamically -->
+            </select>
+          </div>
+          <div class="mb-3">
+            <label class="form-label fw-bold">2. Select Profile</label>
+            <select id="steelProfileSelect" class="form-select border-dark" onchange="onSteelProfileChange()">
+              <!-- Populated dynamically -->
+            </select>
+            <input type="text" id="steelCustomProfile" class="form-control mt-2 d-none" placeholder="Enter custom profile name">
+          </div>
+          <div class="mb-3">
+            <label class="form-label fw-bold">3. Size / Area</label>
+            <div class="d-flex gap-2">
+              <input type="number" id="steelSizeInput" class="form-control border-dark" placeholder="E.g. 2.5" min="0" step="0.01">
+              <select id="steelUnitSelect" class="form-select border-dark" style="width: 100px;">
+                <option value="m">m</option>
+                <option value="m²">m²</option>
+                <option value="mm">mm</option>
+              </select>
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">CANCEL</button>
+          <button type="button" class="btn btn-dark" onclick="addSteelFromModal()">ADD MATERIAL</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Log Welder Steel Modal -->
+  <div class="modal fade" id="welderSteelModal" tabindex="-1">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title brand-font">Log Welder Steel</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body p-3">
+          <div class="mb-3">
+            <label class="form-label fw-bold">1. Select Order</label>
+            <select id="wsOrderSelect" class="form-select border-dark">
+              <!-- Populated dynamically -->
+            </select>
+          </div>
+          <div class="mb-3">
+            <label class="form-label fw-bold">2. Select Welder</label>
+            <select id="wsWorkerSelect" class="form-select border-dark">
+              <!-- Populated dynamically -->
+            </select>
+          </div>
+          <div class="mb-3">
+            <label class="form-label fw-bold">3. Select Category</label>
+            <select id="wsCategorySelect" class="form-select border-dark" onchange="onWsCategoryChange()">
+              <!-- Populated dynamically -->
+            </select>
+          </div>
+          <div class="mb-3">
+            <label class="form-label fw-bold">4. Select Profile</label>
+            <select id="wsProfileSelect" class="form-select border-dark" onchange="onWsProfileChange()">
+              <option value="">-- Select Category First --</option>
+            </select>
+            <input type="text" id="wsCustomProfile" class="form-control mt-2 d-none" placeholder="Enter custom profile name">
+          </div>
+          <div class="mb-3">
+            <label class="form-label fw-bold">5. Size / Area</label>
+            <div class="d-flex gap-2">
+              <input type="number" id="wsSizeInput" class="form-control border-dark" placeholder="E.g. 2.5" min="0" step="0.01">
+              <select id="wsUnitSelect" class="form-select border-dark" style="width: 100px;">
+                <option value="m">m</option>
+                <option value="m²">m²</option>
+                <option value="mm">mm</option>
+              </select>
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">CANCEL</button>
+          <button type="button" class="btn btn-dark" id="btnSubmitWs" onclick="submitWelderSteel()">ADD TO SHEET</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script>
+    let appData = { users:[], workerStats: {}, currentOrders:[], steelProfiles:[] };
+    let session = { role: null, name: null, pendingRow: null, activeOrder: null, logId: null, logIds: {}, isAdmin: false, pendingBatchRows: null, pendingBatchMates: [] };
+    let activityChart = null;
+    let batchWorkModal = null;
+    let refreshInterval = null;
+    let liveTimerInterval = null;
+    let hasSigned = false;
+    let confirmCallback = null;
+    let isSubmitting = false; 
+    let comparisonChart = null;
+    
+    // Mobile breakpoint constant
+    const MOBILE_BREAKPOINT = 768;
+
+    // --- QC DATA ---
+    const QC_DATA = {
+      'Profile Cutting': [
+        "Do the dimensions match the Job Card?", 
+        "Have all items been cut?", 
+        "Are all angles cut correctly?", 
+        "Are the edges clean and deburred?"
+      ],
+      'Plate Cutting': [
+        "Do the dimensions match the specifications?", 
+        "Is the plate thickness correct?", 
+        "Are the edges clean and deburred?", 
+        "Has scrap been minimized?"
+      ],
+      'Tagging': [
+        "Does the drawing match the description?", 
+        "Have all mistakes been corrected?", 
+        "Do the measurements match?", 
+        "Is the frame square?", 
+        "Does the glass fit properly?"
+      ],
+      'Welding': [
+        "Have all tag spots been welded?", 
+        "Are all plates welded flush?", 
+        "Is the unit free from dents and scratches?", 
+        "Is the frame still square?", 
+        "Does the glass still fit properly?"
+      ],
+      'Grinding': [
+        "Have all welds been ground flush?", 
+        "Is the surface free from deep scratches?", 
+        "Is the surface smooth?", 
+        "Is the unit ready for powder coating?"
+      ],
+      
+      // PRE-POWDER (Standard QC Role)
+      'Quality Control': ["Does the unit match the description of the Job Card?", "If there is a drawing, does the unit match the drawing?", "Is the frame square?", "Will the glass fit?", "Are the overall dimensions correct?", "Are all the required welding spots welded?", "Have all welding spots been grinded and polished?", "Does the hinges have enough clearance for the doors to open properly?", "Are the welds on the bullet hinges adequately strong?", "Are the plates free from dents, holes and weld marks?", "Are weld areas free from spatter and holes?", "Is the overall grinding of the unit uniform and smooth?", "Have powder coating stickers been placed on the unit?", "Do the stickers colour match the colour of the Job Card?"],
+      
+      // NEW: POST ASSEMBLE CHECKLIST (From your image - No Photos/PDF)
+      'Assembly': [
+        "Did you cut and paint the backboard before fitting the glass?",
+        "Did you fit the glass and make sure the glass clips align?",
+        "Did you fit the handles, magnets and End Caps?",
+        "Are the magnets and handles aligned and free of scratches?",
+        "Did you fit the back board and make sure the screws are hidden?",
+        "Did you wipe down the unit and remove excess silicon?",
+        "Did you place rubber bumpers on the glass shelves and magnets?",
+        "Did you level the unit for QC?",
+        "Did you notify the cleaner that the unit is ready to be cleaned?"
+      ],
+
+      // NEW: FINAL QC (Old Assembly Checklist - Generates PDF)
+      'Final QC': [
+        "Is the paint free of scratches?", 
+        "Have the edges of the backboard been smoothed out?", 
+        "Is the back board paint free of lines?", 
+        "Is the glass free of scratches?", 
+        "Are all screws flush and level?", 
+        "Are the glass clips straight and level with one another?", 
+        "Are all doors straight and level?", 
+        "Are the doors opening easily?", 
+        "Are the magnets straight and level?", 
+        "Are the end caps fitted?", 
+        "Have the glass shelves been checked and fitted?", 
+        "Is the product level?"
+      ]
+    };
+
+    // --- PHOTO REQUIREMENTS ---
+    const PHOTO_REQS = {
+      'Quality Control': ['Front', 'Left Side', 'Right Side', 'Back', 'Open', 'Top (Optional)', 'Level 1', 'Level 2 (Optional)'],
+      // Assembly now has NO photos
+      'Final QC': ['Front', 'Level 1', 'Back', 'Left Side', 'Right Side', 'Job Card', 'Open', 'Top (Optional)', 'Level 2 (Optional)']
+    };
+
+    let passModal, startModal, pauseModal, qcModal, alertModal, confirmModal, glassCheckModal, weeklyDetailsModal, steelSelectionModal, welderSteelModal, canvas, ctx, isDrawing = false;
+
+    // =====================================================
+    // THEME MANAGEMENT
+    // =====================================================
+    function applyTheme(theme) {
+      const html = document.documentElement;
+      const icon = document.getElementById('themeToggleIcon');
+      const label = document.getElementById('themeToggleLabel');
+      if (theme === 'dark') {
+        html.setAttribute('data-theme', 'dark');
+        if (icon) { icon.className = 'bi bi-sun-fill'; }
+        if (label) label.textContent = 'Light';
+      } else {
+        html.removeAttribute('data-theme');
+        if (icon) { icon.className = 'bi bi-moon-stars-fill'; }
+        if (label) label.textContent = 'Dark';
+      }
+    }
+
+    function toggleTheme() {
+      const current = document.documentElement.getAttribute('data-theme');
+      const next = current === 'dark' ? 'light' : 'dark';
+      localStorage.setItem('sd-theme', next);
+      applyTheme(next);
+    }
+
+    // Apply saved theme as early as possible to avoid flash
+    (function() {
+      const saved = localStorage.getItem('sd-theme') || 'light';
+      applyTheme(saved);
+    })();
+
+    document.addEventListener('DOMContentLoaded', () => {
+      // Initialize mobile menu first (doesn't depend on Bootstrap)
+      initMobileMenu();
+      
+      // Initialize Bootstrap modals (wrapped in try-catch in case Bootstrap doesn't load)
+      try {
+        passModal = new bootstrap.Modal('#passModal');
+        startModal = new bootstrap.Modal('#startModal');
+        pauseModal = new bootstrap.Modal('#pauseModal');
+        glassCheckModal = new bootstrap.Modal('#glassCheckModal');
+        qcModal = new bootstrap.Modal('#qcModal');
+        alertModal = new bootstrap.Modal('#alertModal');
+        confirmModal = new bootstrap.Modal('#confirmModal');
+        weeklyDetailsModal = new bootstrap.Modal('#weeklyDetailsModal');
+        steelSelectionModal = new bootstrap.Modal('#steelModal');
+        welderSteelModal = new bootstrap.Modal('#welderSteelModal');
+        batchWorkModal = new bootstrap.Modal('#batchWorkModal');
+        
+        document.getElementById('confirmBtnYes').onclick = () => { if (confirmModal) confirmModal.hide(); if(confirmCallback) confirmCallback(); };
+        
+        // Initialize canvas when QC modal is fully shown to ensure proper dimensions
+        document.getElementById('qcModal').addEventListener('shown.bs.modal', function () {
+          initCanvas();
+        });
+      } catch(e) {
+        console.warn('Bootstrap modals not initialized:', e);
+      }
+      
+      initSigPad();
+      try {
+        initApp();
+        startLiveTimers();
+      } catch(e) {
+        console.warn('App initialization error (expected in local development):', e);
+      }
+    });
+    
+    function initMobileMenu() {
+      const sidebar = document.getElementById('sidebar');
+      const menuBtn = document.getElementById('mobileMenuBtn');
+      const backdrop = document.getElementById('mobileBackdrop');
+      
+      function toggleMobileMenu() {
+        sidebar.classList.toggle('mobile-open');
+        backdrop.classList.toggle('show');
+      }
+      
+      function closeMobileMenu() {
+        sidebar.classList.remove('mobile-open');
+        backdrop.classList.remove('show');
+      }
+      
+      menuBtn.addEventListener('click', toggleMobileMenu);
+      backdrop.addEventListener('click', closeMobileMenu);
+      
+      // Close menu when navigation link is clicked
+      document.querySelectorAll('.sidebar-link').forEach(link => {
+        link.addEventListener('click', () => {
+          if (window.innerWidth <= MOBILE_BREAKPOINT) {
+            closeMobileMenu();
+          }
+        });
+      });
+      
+      // Close menu when logout is clicked
+      const logoutBtn = sidebar.querySelector('.sidebar-footer .btn');
+      if (logoutBtn) {
+        logoutBtn.addEventListener('click', () => {
+          if (window.innerWidth <= MOBILE_BREAKPOINT) {
+            closeMobileMenu();
+          }
+        });
+      }
+    }
+
+    function showAlert(msg) { 
+      document.getElementById('alertMsg').innerText = msg; 
+      if (alertModal) alertModal.show(); 
+    }
+    function showConfirm(msg, cb) { 
+      document.getElementById('confirmMsg').innerText = msg; 
+      confirmCallback = cb; 
+      if (confirmModal) confirmModal.show(); 
+    }
+
+    function navTo(viewId) {
+      document.querySelectorAll('.view-section').forEach(el => el.classList.add('d-none-view'));
+      document.getElementById(viewId).classList.remove('d-none-view');
+      document.querySelectorAll('.sidebar-link').forEach(l => l.classList.remove('active'));
+      let linkId = '';
+      if(viewId === 'view-global-login' || viewId === 'view-roles' || viewId === 'view-users' || viewId === 'view-dashboard') linkId = 'link-roles';
+      if(viewId === 'view-admin-prod') linkId = 'link-prod';
+      if(viewId === 'view-admin-workers') linkId = 'link-work';
+      if(viewId === 'view-admin-metrics') linkId = 'link-metrics';
+      if(viewId === 'view-admin-qc-reports') linkId = 'link-reports';
+      if(viewId === 'view-admin-activity') linkId = 'link-activity';
+      const linkEl = document.getElementById(linkId); if(linkEl) linkEl.classList.add('active');
+      if(viewId !== 'view-dashboard') stopAutoRefresh();
+    }
+
+    function initApp() {
+      // Fire both backend calls in parallel; hide loader after both return.
+      let usersLoaded = false;
+      let profilesLoaded = false;
+      function checkAllLoaded() {
+        if (usersLoaded && profilesLoaded) {
+          document.getElementById('loader').classList.add('d-none');
+        }
+      }
+      google.script.run.withSuccessHandler(data => {
+        appData.users = data;
+        renderRoles();
+        usersLoaded = true;
+        checkAllLoaded();
+      }).withFailureHandler(() => { usersLoaded = true; checkAllLoaded(); }).getUsersAndRoles();
+
+      google.script.run.withSuccessHandler(profiles => {
+        appData.steelProfiles = profiles || [];
+        profilesLoaded = true;
+        checkAllLoaded();
+      }).withFailureHandler(() => { profilesLoaded = true; checkAllLoaded(); }).getSteelProfiles();
+    }
+
+    function renderRoles() {
+      const grid = document.getElementById('roleGrid'); grid.innerHTML = '';
+      [...new Set(appData.users.map(u => u.role))].sort().forEach(r => {
+        grid.innerHTML += `<div class="col-sm-6 col-md-4 col-lg-3"><div class="card p-4 text-center h-100 role-card" onclick="selectRole('${r}')"><h4>${r}</h4></div></div>`;
+      });
+    }
+
+    function selectRole(r) { session.role = r; if(r.toLowerCase() === 'admin') promptPass('Admin'); else renderUsers(r); }
+    function renderUsers(r) {
+      const list = document.getElementById('userList'); document.getElementById('selectedRoleTitle').innerText = r; list.innerHTML = '';
+      appData.users.filter(u => u.role === r).forEach(u => list.innerHTML += `<button class="list-group-item list-group-item-action py-3 fw-bold" onclick="promptPass('${u.name}')">${u.name}</button>`);
+      navTo('view-users');
+    }
+    function promptPass(n) { 
+      session.name = n; 
+      document.getElementById('passPromptName').innerText = "Code for " + n; 
+      document.getElementById('inputPass').value=''; 
+      if (passModal) passModal.show(); 
+    }
+
+    function submitGlobalLogin() {
+      const name = document.getElementById('globalLoginName').value;
+      const pass = document.getElementById('globalLoginPass').value;
+      if (!name || !pass) {
+        showAlert("Please enter both name and password.");
+        return;
+      }
+      
+      const btn = document.getElementById('btnGlobalLogin');
+      const origText = btn.innerHTML;
+      btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span> UNLOCKING...';
+      btn.disabled = true;
+
+      google.script.run.withSuccessHandler(res => {
+        btn.innerHTML = origText;
+        btn.disabled = false;
+        if(res.success) {
+          navTo('view-roles');
+        } else {
+          showAlert(res.error);
+        }
+      }).withFailureHandler(err => {
+        btn.innerHTML = origText;
+        btn.disabled = false;
+        showAlert("Connection error: " + err);
+      }).verifyGlobalLogin(name, pass);
+    }
+
+    function submitPass() {
+      const p = document.getElementById('inputPass').value;
+      google.script.run.withSuccessHandler(res => {
+        if(res.success) { 
+          session.isAdmin = res.isAdmin; 
+          if (passModal) passModal.hide(); 
+          if(session.role === 'Admin') {
+            document.getElementById('adminLinks').classList.remove('d-none-view');
+            loadProductionOverview();
+            loadIdleWorkers();
+          } else {
+            document.getElementById('adminLinks').classList.add('d-none-view');
+            enterDashboard();
+          }
+        } else showAlert(res.error);
+      }).verifyLogin(session.role, session.name, p);
+    }
+    
+    function logout() { 
+      session = { role: null, name: null, pendingRow: null, activeOrder: null, logId: null, logIds: {}, isAdmin: false, pendingBatchRows: null, pendingBatchMates: [] }; 
+      document.getElementById('adminLinks').classList.add('d-none-view'); 
+      document.getElementById('globalLoginName').value = '';
+      document.getElementById('globalLoginPass').value = '';
+      navTo('view-global-login'); 
+    }
+
+    function filterDashboard() {
+      const q = document.getElementById('dashSearch').value.toLowerCase();
+      const phaseEl = document.getElementById('qcPhaseFilter');
+      const phase = (phaseEl && !phaseEl.parentElement.classList.contains('d-none')) ? phaseEl.value.toLowerCase() : "";
+      
+      document.querySelectorAll('#view-dashboard .card').forEach(c => {
+        // Target the wrapper label if it exists
+        const wrapper = c.closest('.checkbox-wrapper-16') || c;
+        const txt = c.querySelector('h4').innerText.toLowerCase();
+        const statusBadge = c.querySelector('.badge.bg-dark');
+        const cardStatus = statusBadge ? statusBadge.innerText.toLowerCase() : "";
+        
+        const matchesText = txt.includes(q);
+        const matchesPhase = phase === "" || cardStatus === phase;
+        
+        if (matchesText && matchesPhase) {
+            wrapper.style.display = '';
+        } else {
+            wrapper.style.display = 'none';
+            const chk = wrapper.querySelector('.batch-select');
+            if(chk) chk.checked = false; // Uncheck hidden boxes
+        }
+      });
+      toggleBatchButtons(); 
+    }
+
+    function toggleBatchButtons() {
+        const selected = document.querySelectorAll('.batch-select:checked');
+        const container = document.getElementById('batchActionContainer');
+        const btnStart = document.getElementById('btnBatchStart');
+        const btnFinish = document.getElementById('btnBatchFinish');
+        
+        if(selected.length === 0) {
+            container.classList.add('d-none');
+            return;
+        }
+        
+        container.classList.remove('d-none');
+        document.getElementById('batchCount').innerText = `${selected.length} Selected`;
+        
+        let canStart = false;
+        let canFinish = false;
+        
+        selected.forEach(chk => {
+            const s = chk.getAttribute('data-status');
+            if(s === 'ready for powder coating' || s === 'ready for delivery') canStart = true;
+            if(s === 'powder coating' || s === 'out for delivery') canFinish = true;
+        });
+        
+        // Show the correct button based on selection
+        if(canStart && !canFinish) {
+            btnStart.classList.remove('d-none');
+            btnFinish.classList.add('d-none');
+        } else if(canFinish && !canStart) {
+            btnFinish.classList.remove('d-none');
+            btnStart.classList.add('d-none');
+        } else {
+            // Cannot start and finish mixed items at the same time
+            btnStart.classList.add('d-none');
+            btnFinish.classList.add('d-none');
+            document.getElementById('batchCount').innerText = `${selected.length} Selected (Mixed types!)`;
+        }
+    }
+
+    function batchStart() {
+        const selected = Array.from(document.querySelectorAll('.batch-select:checked')).map(el => parseInt(el.value));
+        if(selected.length === 0) return;
+        
+        isSubmitting = true;
+        const btn = document.getElementById('btnBatchStart');
+        const origText = btn.innerHTML;
+        btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span> STARTING...';
+        btn.disabled = true;
+
+        // NEW: Reset the Phase Filter to "All" so the user can see their newly started orders
+        const phaseFilter = document.getElementById('qcPhaseFilter');
+        if (phaseFilter) phaseFilter.value = "";
+        
+        google.script.run
+            .withSuccessHandler(res => {
+                isSubmitting = false;
+                btn.innerHTML = origText;
+                btn.disabled = false;
+                loadDashboard(true);
+            })
+            .withFailureHandler(err => {
+                isSubmitting = false;
+                btn.innerHTML = origText;
+                btn.disabled = false;
+                showAlert("Error: " + err);
+                loadDashboard(true);
+            })
+            .batchStartOrders(selected, session.name, session.role);
+    }
+    
+    function batchFinish() {
+        const selected = Array.from(document.querySelectorAll('.batch-select:checked')).map(el => parseInt(el.value));
+        if(selected.length === 0) return;
+        
+        showConfirm(`Finish ${selected.length} selected orders?`, () => {
+            isSubmitting = true;
+            const btn = document.getElementById('btnBatchFinish');
+            const origText = btn.innerHTML;
+            btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span> FINISHING...';
+            btn.disabled = true;
+            
+            google.script.run
+                .withSuccessHandler(res => {
+                    isSubmitting = false;
+                    btn.innerHTML = origText;
+                    btn.disabled = false;
+                    loadDashboard(true);
+                })
+                .withFailureHandler(err => {
+                    isSubmitting = false;
+                    btn.innerHTML = origText;
+                    btn.disabled = false;
+                    showAlert("Error: " + err);
+                    loadDashboard(true);
+                })
+                .batchFinishOrders(selected, session.name);
+        });
+    }
+
+    function filterProduction() {
+      const q = document.getElementById('prodSearch').value.toLowerCase();
+      document.querySelectorAll('#view-admin-prod .card').forEach(c => {
+        const txt = c.querySelector('button div strong').innerText.toLowerCase();
+        c.style.display = txt.includes(q) ? '' : 'none';
+      });
+    }
+
+    function filterWorkerLogs() {
+      const q = document.getElementById('workerLogSearch').value.toLowerCase();
+      document.querySelectorAll('#workerLogTable tbody tr').forEach(row => {
+        const txt = row.cells[1].innerText.toLowerCase(); 
+        row.style.display = txt.includes(q) ? '' : 'none';
+      });
+    }
+
+    function enterDashboard() {
+      navTo('view-dashboard');
+      document.getElementById('dashUser').innerText = session.name;
+      document.getElementById('dashRole').innerText = session.role;
+      const tabEl = document.querySelector('#dashTabs button[data-bs-target="#pane-available"]');
+      if(tabEl) new bootstrap.Tab(tabEl).show();
+      loadDashboard(false);
+      startAutoRefresh();
+    }
+    function startAutoRefresh() {
+      if (refreshInterval) clearInterval(refreshInterval);
+      refreshInterval = setInterval(() => { 
+        // Don't refresh if a modal is open OR if we are currently submitting data
+        if (!document.querySelector('.modal.show') && !isSubmitting) {
+            loadDashboard(true); 
+        }
+      }, 30000); 
+    }
+    function stopAutoRefresh() { if (refreshInterval) clearInterval(refreshInterval); }
+
+    function loadDashboard(silent = false) {
+      if(!silent) document.getElementById('container-available').innerHTML = '<div class="spinner-border"></div>';
+      google.script.run.withSuccessHandler(orders => {
+        appData.currentOrders = orders; // Cache orders for the modal
+        
+        // 1. Only Siya can see the Powder Coating List Button
+        const btnPowder = document.getElementById('btnPowderList');
+        if (session.name && session.name.trim().toLowerCase() === 'siya') {
+          const hasReady = orders.some(o => o.status.toLowerCase() === 'ready for powder coating');
+          if (hasReady && btnPowder) btnPowder.classList.remove('d-none');
+          else if (btnPowder) btnPowder.classList.add('d-none');
+        } else if (btnPowder) {
+          btnPowder.classList.add('d-none');
+        }
+
+        // 1.5. Profile Cutters can see Log Welder Steel button
+        const btnWelderSteel = document.getElementById('btnLogWelderSteel');
+        if (session.role === 'Profile Cutting') {
+          if (btnWelderSteel) btnWelderSteel.classList.remove('d-none');
+        } else if (btnWelderSteel) {
+          btnWelderSteel.classList.add('d-none');
+        }
+
+        // 2. Populate Production Phase Filter for QC roles
+        const filterContainer = document.getElementById('qcPhaseFilterContainer');
+        if (session.role === 'Quality Control' || session.role === 'Admin') {
+            filterContainer.classList.remove('d-none');
+            const filterEl = document.getElementById('qcPhaseFilter');
+            const currentVal = filterEl.value; // Save selection to prevent reset on auto-refresh
+            const uniqueStatuses =[...new Set(orders.map(o => o.status))].sort();
+            
+            filterEl.innerHTML = '<option value="">All Production Phases</option>';
+            uniqueStatuses.forEach(s => {
+                const selected = (s === currentVal) ? 'selected' : '';
+                filterEl.innerHTML += `<option value="${s}" ${selected}>${s}</option>`;
+            });
+        } else {
+            filterContainer.classList.add('d-none');
+        }
+
+        const av = document.getElementById('container-available');
+        const pr = document.getElementById('container-progress');
+
+        // --- DOM DIFFING (Step 3.1) ---
+        // Build a lookup map of incoming orders by rowIndex for O(1) access.
+        const incomingMap = {};
+        orders.forEach(o => { incomingMap[o.rowIndex] = o; });
+
+        // Clear any loading spinners injected by the non-silent path.
+        // They have no id so the card-removal pass below cannot reach them.
+        av.querySelector('.spinner-border')?.remove();
+        pr.querySelector('.spinner-border')?.remove();
+
+        // A. Remove cards that are no longer in the server response.
+        document.querySelectorAll('#container-available [id^="card-"], #container-progress [id^="card-"]').forEach(cardEl => {
+          const rowIndex = parseInt(cardEl.id.replace('card-', ''));
+          if (!incomingMap[rowIndex]) {
+            // Card no longer exists — remove its wrapper too (checkbox-wrapper-16 or the card itself)
+            const wrapper = cardEl.closest('.checkbox-wrapper-16') || cardEl;
+            wrapper.remove();
+          }
+        });
+
+        // B. Update existing cards and append new ones.
+        if (!session.logIds) session.logIds = {};
+        orders.forEach(o => {
+          if (o.logId && o.assigned === session.name) session.logIds[o.order] = o.logId;
+        });
+        orders.forEach(o => {
+          const isMine = o.assigned === session.name;
+          const isLocked = o.assigned && !isMine;
+          const cardId = `card-${o.rowIndex}`;
+          const existingCard = document.getElementById(cardId);
+          const productLine = o.productName ? `<div class="product-sub">${o.productName}</div>` : '';
+
+          let innerBtn = '';
+          if (session.isAdmin) {
+             innerBtn = `<button class="btn btn-secondary w-100 position-relative" style="z-index: 10;" disabled><i class="bi bi-eye-fill"></i> ADMIN VIEW ONLY</button>`;
+          } else {
+             if (isMine) {
+               if (o.isPaused) {
+                 innerBtn = `<button class="btn btn-success w-100 position-relative" style="z-index: 10;" onclick="event.stopPropagation(); event.preventDefault(); confirmResume(${o.rowIndex}, '${o.order}')">RESUME</button>`;
+               } else {
+                 innerBtn = `
+                   <div class="d-flex gap-2 position-relative w-100 flex-wrap" style="z-index: 10;">
+                     <button class="btn btn-warning flex-grow-1" style="flex-basis: 0;" onclick="event.stopPropagation(); event.preventDefault(); prePause(${o.rowIndex}, '${o.order}')">PAUSE</button>
+                     <button class="btn btn-success flex-grow-1" style="flex-basis: 0;" onclick="event.stopPropagation(); event.preventDefault(); preFinish(${o.rowIndex}, '${o.order}')">FINISH & QC</button>
+                     ${o.isBatched ? `<button class="btn btn-outline-dark w-100 mt-1" onclick="event.stopPropagation(); event.preventDefault(); leaveBatchNow('${o.order}')">WORK THIS ORDER ONLY</button>` : ''}
+                   </div>
+                 `;
+               }
+             }
+             else if(isLocked) innerBtn = `<button class="btn btn-secondary w-100 position-relative" style="z-index: 10;" disabled>LOCKED BY ${o.assigned}</button>`;
+             else innerBtn = `<button class="btn btn-primary w-100 position-relative" style="z-index: 10;" onclick="event.stopPropagation(); event.preventDefault(); preStart(${o.rowIndex}, '${o.order}')">START</button>`;
+          }
+          let btn = `<div class="action-btn-container w-100">${innerBtn}</div>`;
+
+          let statusBadge = o.isPlateOrder ? `<span class="badge bg-warning text-dark me-2">Plate Cutting</span>` : '';
+          if (o.isBatched) statusBadge += `<span class="badge badge-batch me-2">Together</span>`;
+          if (o.isPaused && o.pauseReason) {
+             statusBadge += `<span class="badge bg-warning text-dark me-2">Paused: ${o.pauseReason}</span>`;
+          }
+          const lowerStatus = String(o.status).toLowerCase();
+          const batchStartStatuses =['ready for powder coating', 'ready for delivery'];
+          const batchFinishStatuses =['powder coating', 'out for delivery'];
+          let isSelectable = false;
+          if (!isLocked && !session.isAdmin) {
+             if ((!isMine && batchStartStatuses.includes(lowerStatus)) || (isMine && batchFinishStatuses.includes(lowerStatus))) {
+                 isSelectable = true;
+             }
+          }
+
+          if (existingCard) {
+            // --- WRAPPER STATE MISMATCH CHECK ---
+            // If the card's "batch-selectable" state has changed (e.g., order moved into or out of
+            // 'Ready for Powder Coating'), the entire card must be destroyed and recreated from scratch
+            // because the outer HTML structure changes between a plain <div> and a <label> wrapper.
+            const existingWrapper = existingCard.closest('.checkbox-wrapper-16');
+            const currentlySelectable = !!existingWrapper;
+            if (currentlySelectable !== isSelectable) {
+              // Destroy the card (and its wrapper if present) and fall through to the append block.
+              (existingWrapper || existingCard).remove();
+            }
+          }
+
+          if (document.getElementById(cardId)) {
+            // --- UPDATE EXISTING CARD IN-PLACE ---
+            const liveCard = document.getElementById(cardId);
+            // Update status bar colour
+            const statusBar = liveCard.querySelector('.status-bar');
+            if (statusBar) {
+              statusBar.className = 'status-bar ' + (isMine ? 'bar-running' : (isLocked ? 'bar-locked' : 'bar-ready'));
+            }
+            // Update status badge text
+            const badge = liveCard.querySelector('.badge.bg-dark');
+            if (badge) badge.innerText = o.status;
+            // Update action button
+            const btnContainer = liveCard.querySelector('.card-body');
+            if (btnContainer) {
+              const oldBtn = btnContainer.querySelector('.action-btn-container') || btnContainer.querySelector('button');
+              if (oldBtn) oldBtn.outerHTML = btn;
+            }
+            // Move card to correct container if assignment changed
+            const showInProgress = isMine || (o.status === 'In Progress' && !isLocked);
+            const targetContainer = showInProgress ? pr : av;
+            const currentContainer = liveCard.closest('#container-available, #container-progress');
+            if (currentContainer && currentContainer !== targetContainer) {
+              const wrapper = liveCard.closest('.checkbox-wrapper-16') || liveCard;
+              targetContainer.appendChild(wrapper);
+            }
+
+          } else {
+            // --- APPEND NEW CARD ---
+            let html = '';
+            if (isSelectable) {
+              html = `
+              <label class="checkbox-wrapper-16 animate-card" id="wrapper-${cardId}">
+                <input class="checkbox-input batch-select" type="checkbox" value="${o.rowIndex}" data-order="${o.order}" data-status="${lowerStatus}" onchange="toggleBatchButtons()">
+                <div class="card checkbox-tile h-100 m-0" id="${cardId}">
+                  <div class="status-bar ${isMine?'bar-running':'bar-ready'}"></div>
+                  <div class="card-body">
+                    <div class="d-flex justify-content-between align-items-center mb-2">
+                      <h4 class="d-flex align-items-center m-0">
+                        <span class="custom-check-circle"></span>
+                        ${o.order}
+                      </h4>
+                      ${productLine}
+                      <div>${statusBadge}<span class="badge bg-dark">${o.status}</span></div>
+                    </div>
+                    ${btn}
+                  </div>
+                </div>
+              </label>`;
+            } else {
+              html = `
+              <div class="card mb-3 animate-card" id="${cardId}">
+                <div class="status-bar ${isMine?'bar-running':(isLocked?'bar-locked':'bar-ready')}"></div>
+                <div class="card-body">
+                  <div class="d-flex justify-content-between align-items-center mb-2">
+                    <h4 class="m-0">${o.order}</h4>
+                    ${productLine}
+                    <div>${statusBadge}<span class="badge bg-dark">${o.status}</span></div>
+                  </div>
+                  ${btn}
+                </div>
+              </div>`;
+            }
+
+            const showInProgress = isMine || (o.status === 'In Progress' && !isLocked);
+            const tempDiv = document.createElement('div');
+            tempDiv.innerHTML = html;
+            const newEl = tempDiv.firstElementChild;
+            if(showInProgress) pr.appendChild(newEl);
+            else av.appendChild(newEl);
+          }
+        });
+
+        filterDashboard(); 
+        google.script.run.withSuccessHandler(notice => {
+          if (notice && notice.resumedOrder) showSwitchBanner(notice);
+        }).popWorkerNotice(session.name);
+      }).getOrdersForRole(session.role, session.name);
+    }
+    
+    function continueToStartModal() {
+      if (session.role === 'Assembly') {
+        document.getElementById('glassCheckOrder').innerText = session.activeOrder;
+        if (glassCheckModal) glassCheckModal.show();
+      } else {
+        document.getElementById('startModalOrder').innerText = session.activeOrder; 
+        if (startModal) startModal.show(); 
+      }
+    }
+
+    function preStart(row, ord) { 
+      session.pendingRow = row; 
+      session.activeOrder = ord;
+      session.pendingBatchRows = null;
+      session.pendingBatchMates = [];
+
+      const current = (appData.currentOrders || []).find(o => o.rowIndex === row);
+      if (session.role === 'Assembly' && current && current.productName) {
+        const mates = (appData.currentOrders || []).filter(o =>
+          o.rowIndex !== row &&
+          o.productName &&
+          String(o.productName).trim() === String(current.productName).trim() &&
+          !o.isPlateOrder &&
+          (!o.assigned || o.assigned === session.name)
+        );
+        if (mates.length) {
+          session.pendingBatchMates = mates;
+          document.getElementById('batchWorkMsg').innerText =
+            current.productName + ' on ' + ord + ' matches ' + mates.length + ' other order(s). Cut slats together?';
+          document.getElementById('batchWorkList').innerHTML = mates.map(m =>
+            '<div><strong>' + m.order + '</strong> · ' + (m.productName || '') + '</div>'
+          ).join('');
+          if (batchWorkModal) batchWorkModal.show();
+          return;
+        }
+      }
+      continueToStartModal();
+    }
+
+    function confirmBatchTogether() {
+      const mates = session.pendingBatchMates || [];
+      session.pendingBatchRows = [session.pendingRow].concat(mates.map(m => m.rowIndex));
+      if (batchWorkModal) batchWorkModal.hide();
+      continueToStartModal();
+    }
+
+    function confirmBatchOnlyThis() {
+      session.pendingBatchRows = null;
+      if (batchWorkModal) batchWorkModal.hide();
+      continueToStartModal();
+    }
+    
+    function confirmStart() {
+      if (isSubmitting) return; 
+      isSubmitting = true;
+      if (startModal) startModal.hide();
+      
+      // NEW: Reset the Phase Filter to "All" so the user can see their newly started order
+      const phaseFilter = document.getElementById('qcPhaseFilter');
+      if (phaseFilter) phaseFilter.value = "";
+
+      const card = document.getElementById(`card-${session.pendingRow}`);
+      if(card) {
+        card.querySelector('.status-bar').className = 'status-bar bar-running';
+        card.querySelector('button').outerHTML = `<button class="btn btn-success w-100 position-relative" style="z-index: 10;" disabled>SYNCING...</button>`;
+        // Move the wrapper instead of just the card
+        const wrapper = card.closest('.checkbox-wrapper-16') || card;
+        document.getElementById('container-progress').appendChild(wrapper);
+        new bootstrap.Tab(document.querySelector('#dashTabs button[data-bs-target="#pane-progress"]')).show();
+      }
+      google.script.run.withSuccessHandler(res => { 
+        isSubmitting = false;
+        if(res.success) {
+           session.logId = res.logId;
+           if (!session.logIds) session.logIds = {};
+           if (res.started) {
+             res.started.forEach(s => { if (s.logId && s.order) session.logIds[s.order] = s.logId; });
+           } else if (res.logId && session.activeOrder) {
+             session.logIds[session.activeOrder] = res.logId;
+           }
+           session.pendingBatchRows = null;
+           loadDashboard(true);
+        } else {
+           showAlert(res.message || res.error || "Could not start");
+           loadDashboard();
+        }
+      }).withFailureHandler(err => { isSubmitting=false; showAlert("Error: "+err); loadDashboard(); }).startOrder(session.pendingRow, session.name, session.role, session.pendingBatchRows);
+    }
+
+    function prePause(row, ord) {
+      session.pendingRow = row;
+      session.activeOrder = ord;
+      document.getElementById('pauseModalOrder').innerText = ord;
+      if (pauseModal) pauseModal.show();
+    }
+
+    function confirmPause() {
+      if (isSubmitting) return;
+      isSubmitting = true;
+      if (pauseModal) pauseModal.hide();
+      
+      const reason = document.getElementById('pauseReasonSelect').value;
+      const card = document.getElementById(`card-${session.pendingRow}`);
+      if(card) {
+        card.querySelector('.status-bar').className = 'status-bar bar-locked';
+        const actionContainer = card.querySelector('.action-btn-container') || card.querySelector('.card-body > button');
+        if (actionContainer) actionContainer.outerHTML = `<div class="action-btn-container w-100"><button class="btn btn-warning w-100 position-relative" style="z-index: 10;" disabled>PAUSING...</button></div>`;
+      }
+      
+      google.script.run.withSuccessHandler(res => {
+        isSubmitting = false;
+        if(res.success) {
+           loadDashboard(true);
+        } else {
+           showAlert(res.message);
+           loadDashboard();
+        }
+      }).withFailureHandler(err => { isSubmitting=false; showAlert("Error: "+err); loadDashboard(); }).workerPauseOrder(session.pendingRow, session.activeOrder, session.name, reason);
+    }
+
+    function confirmResume(row, ord) {
+      if (isSubmitting) return;
+      isSubmitting = true;
+      session.pendingRow = row;
+      session.activeOrder = ord;
+      
+      const card = document.getElementById(`card-${session.pendingRow}`);
+      if(card) {
+        card.querySelector('.status-bar').className = 'status-bar bar-running';
+        const actionContainer = card.querySelector('.action-btn-container') || card.querySelector('.card-body > button');
+        if (actionContainer) actionContainer.outerHTML = `<div class="action-btn-container w-100"><button class="btn btn-success w-100 position-relative" style="z-index: 10;" disabled>RESUMING...</button></div>`;
+      }
+      
+      google.script.run.withSuccessHandler(res => {
+        isSubmitting = false;
+        if(res.success) {
+           loadDashboard(true);
+        } else {
+           showAlert(res.message);
+           loadDashboard();
+        }
+      }).withFailureHandler(err => { isSubmitting=false; showAlert("Error: "+err); loadDashboard(); }).workerResumeOrder(session.pendingRow, session.activeOrder, session.name);
+    }
+
+    function glassIsFine() {
+      if (glassCheckModal) glassCheckModal.hide();
+      confirmStart(); // Start the timer normally
+    }
+
+    function glassIsScratched() {
+      if (isSubmitting) return;
+      isSubmitting = true;
+      if (glassCheckModal) glassCheckModal.hide();
+      
+      document.getElementById('container-available').innerHTML = '<div class="spinner-border"></div>';
+      
+      google.script.run
+        .withSuccessHandler(res => {
+          isSubmitting = false;
+          showAlert("Management has been notified about the scratched glass. You cannot start this order.");
+          loadDashboard();
+        })
+        .withFailureHandler(err => {
+          isSubmitting = false;
+          showAlert("Error: " + err);
+          loadDashboard();
+        })
+        .reportScratchedGlass(session.activeOrder, session.name);
+    }
+    
+    function preFinish(row, ord) { 
+      session.pendingRow = row; 
+      session.activeOrder = ord; 
+      
+      // 1. GET STATUS FROM CARD BADGE
+      const card = document.getElementById(`card-${row}`);
+      const statusText = card ? card.querySelector('.badge.bg-dark').innerText.toLowerCase().trim() : "";
+      
+      // 2. DETERMINE WHICH CHECKLIST TO USE
+      let qcKey = 'Profile Cutting'; // Default fallback
+      
+      if (statusText === 'final qc') {
+          qcKey = 'Final QC';
+      } else if (statusText === 'assembly') {
+          qcKey = 'Assembly';
+      } else if (QC_DATA[session.role]) {
+          qcKey = session.role;
+      }
+      
+      session.currentQcKey = qcKey; 
+      
+      // 3. EXCEPTIONS: GRINDING, POWDER COATING & DELIVERY (Skip Checklist)
+      // Added "out for delivery" here so it skips the popup form
+      if(session.role === 'Grinding' || statusText === 'powder coating' || statusText === 'out for delivery') { 
+        showConfirm("Finish " + (statusText || "Task") + "?", () => submitQC(true)); 
+        return; 
+      }
+      
+      // 4. GENERATE CHECKLIST HTML
+      const qs = QC_DATA[qcKey] || QC_DATA['Profile Cutting']; 
+      let h = ''; 
+      qs.forEach((q,i) => {
+        h += `<div class="mb-3 border-bottom pb-2"><div class="fw-bold mb-1">${q}</div><div class="btn-group w-100" role="group"><input type="radio" class="btn-check" name="q${i}" id="q${i}y" value="Y" autocomplete="off"><label class="btn btn-outline-success" for="q${i}y">YES</label><input type="radio" class="btn-check" name="q${i}" id="q${i}n" value="N" autocomplete="off"><label class="btn btn-outline-danger" for="q${i}n">NO</label></div></div>`;
+      });
+      document.getElementById('qcChecklistContainer').innerHTML = h;
+
+      // STEP 7: MATERIAL LOGGING SECTION (Profile Cutting & Plate Cutting only)
+      if (qcKey === 'Profile Cutting' || qcKey === 'Plate Cutting') {
+        const materialHtml = `
+          <div id="materialLoggingSection" class="mt-4 pt-3 border-top">
+            <div class="d-flex justify-content-between align-items-center mb-2">
+              <label class="fw-bold">Steel Profiles / Sheets Used <span class="text-danger">*</span></label>
+              <button type="button" class="btn btn-sm btn-outline-dark" onclick="openSteelModal()">
+                <i class="bi bi-plus"></i> Select Steel
+              </button>
+            </div>
+            <div id="materialRowsContainer"></div>
+          </div>`;
+        document.getElementById('qcChecklistContainer').innerHTML += materialHtml;
+      }
+
+      document.getElementById('qcOrderNum').innerText = ord;
+      
+      // 5. PHOTO INPUTS
+      const reqPhotos = PHOTO_REQS[qcKey]; 
+      const phContainer = document.getElementById('qcPhotoContainer');
+      const phInputs = document.getElementById('qcPhotoInputs');
+      phInputs.innerHTML = '';
+      
+      if(reqPhotos) {
+        phContainer.classList.remove('d-none');
+        reqPhotos.forEach((label, idx) => {
+           const isOptional = label.includes('Optional');
+           const requiredAttr = isOptional ? '' : 'required';
+           phInputs.innerHTML += `<div class="mb-2"><label for="photo-input-${idx}">${label}</label><input type="file" id="photo-input-${idx}" class="form-control photo-input" accept="image/*" capture="environment" data-idx="${idx}" data-optional="${isOptional}" ${requiredAttr}></div>`;
+        });
+      } else {
+        phContainer.classList.add('d-none');
+      }
+      
+      clearSignature(); 
+      // initCanvas will be called when modal is shown via event listener
+      if (qcModal) qcModal.show();
+    }
+
+function openSteelModal() {
+      // Reset inputs
+      document.getElementById('steelSizeInput').value = '';
+      const customInput = document.getElementById('steelCustomProfile');
+      customInput.value = '';
+      customInput.classList.add('d-none');
+
+      // Extract unique categories
+      const categories =[...new Set(appData.steelProfiles.map(p => p.category))];
+      if (!categories.includes("Custom")) categories.push("Custom"); // Always allow Custom category fallback
+
+      const catSelect = document.getElementById('steelCategorySelect');
+      catSelect.innerHTML = '<option value="">-- Choose Category --</option>' +
+        categories.map(c => `<option value="${c}">${c}</option>`).join('');
+
+      document.getElementById('steelProfileSelect').innerHTML = '<option value="">-- Select Category First --</option>';
+
+      if (steelSelectionModal) steelSelectionModal.show();
+    }
+
+    function onSteelCategoryChange() {
+      const cat = document.getElementById('steelCategorySelect').value;
+      const profSelect = document.getElementById('steelProfileSelect');
+      const customInput = document.getElementById('steelCustomProfile');
+
+      customInput.classList.add('d-none');
+
+      if (!cat) {
+        profSelect.innerHTML = '<option value="">-- Select Category First --</option>';
+        return;
+      }
+
+      if (cat === 'Custom') {
+         profSelect.innerHTML = '<option value="__custom__">-- Enter Custom Profile --</option>';
+         customInput.classList.remove('d-none');
+         return;
+      }
+
+      const profiles = appData.steelProfiles.filter(p => p.category === cat);
+      let html = '<option value="">-- Choose Profile --</option>';
+      html += profiles.map(p => `<option value="${p.name}">${p.name}</option>`).join('');
+      html += '<option value="__custom__">+ Add Custom Profile</option>';
+
+      profSelect.innerHTML = html;
+    }
+
+    function onSteelProfileChange() {
+      const val = document.getElementById('steelProfileSelect').value;
+      const customInput = document.getElementById('steelCustomProfile');
+      if (val === '__custom__') {
+        customInput.classList.remove('d-none');
+        customInput.focus();
+      } else {
+        customInput.classList.add('d-none');
+      }
+    }
+
+    function addSteelFromModal() {
+      const cat = document.getElementById('steelCategorySelect').value;
+      const profVal = document.getElementById('steelProfileSelect').value;
+      const customName = document.getElementById('steelCustomProfile').value.trim();
+      const size = document.getElementById('steelSizeInput').value.trim();
+      const unit = document.getElementById('steelUnitSelect').value;
+
+      if (!cat || !profVal || !size) {
+        showAlert("Please select a category, profile, and enter a size/area.");
+        return;
+      }
+
+      const isCustom = (profVal === '__custom__');
+      const finalName = isCustom ? customName : profVal;
+
+      if (isCustom && !finalName) {
+         showAlert("Please enter a custom profile name.");
+         return;
+      }
+
+      // Add visual row to QC container
+      const container = document.getElementById('materialRowsContainer');
+      const rowId = 'mrow-' + Date.now();
+      const fullSize = size + ' ' + unit;
+
+      const row = document.createElement('div');
+      row.className = 'material-row d-flex justify-content-between align-items-center mb-2 p-2 border rounded bg-light';
+      row.id = rowId;
+      row.dataset.category = cat;
+      row.dataset.name = finalName;
+      row.dataset.size = fullSize;
+      row.dataset.custom = isCustom;
+
+      row.innerHTML = `
+        <div>
+          <div class="fw-bold">${finalName}</div>
+          <div class="small text-muted">${cat} | ${fullSize}</div>
+        </div>
+        <button type="button" class="btn btn-sm btn-outline-danger" onclick="document.getElementById('${rowId}').remove()" title="Remove">
+          <i class="bi bi-trash"></i>
+        </button>
+      `;
+      container.appendChild(row);
+
+      if (steelSelectionModal) steelSelectionModal.hide();
+    }
+
+    function openWelderSteelModal() {
+      // 1. Reset Form & Disable Order Select while loading
+      const orderSelect = document.getElementById('wsOrderSelect');
+      orderSelect.innerHTML = '<option value="">-- Loading Welding Orders... --</option>';
+      orderSelect.disabled = true;
+      
+      document.getElementById('wsWorkerSelect').innerHTML = '<option value="">-- Select Welder --</option>';
+      document.getElementById('wsCategorySelect').innerHTML = '<option value="">-- Choose Category --</option>';
+      document.getElementById('wsProfileSelect').innerHTML = '<option value="">-- Select Category First --</option>';
+      document.getElementById('wsCustomProfile').value = '';
+      document.getElementById('wsCustomProfile').classList.add('d-none');
+      document.getElementById('wsSizeInput').value = '';
+
+      // 2. Populate Welders List
+      const welders = appData.users.filter(u => u.role === 'Welding');
+      welders.forEach(w => {
+          document.getElementById('wsWorkerSelect').innerHTML += `<option value="${w.name}">${w.name}</option>`;
+      });
+
+      // 3. Populate Categories
+      const categories = [...new Set(appData.steelProfiles.map(p => p.category))];
+      if (!categories.includes("Custom")) categories.push("Custom");
+      categories.forEach(c => {
+          document.getElementById('wsCategorySelect').innerHTML += `<option value="${c}">${c}</option>`;
+      });
+
+      // 4. Fetch the Welding Orders dynamically from the backend
+      google.script.run
+        .withSuccessHandler(orders => {
+            orderSelect.innerHTML = '<option value="">-- Select Order --</option>';
+            if(orders.length === 0) {
+                orderSelect.innerHTML = '<option value="">-- No Welding Orders Available --</option>';
+            } else {
+                orders.forEach(o => {
+                    const nameDisplay = o.productName ? ` - ${o.productName}` : '';
+                    orderSelect.innerHTML += `<option value="${o.order}">${o.order}${nameDisplay}</option>`;
+                });
+            }
+            orderSelect.disabled = false;
+        })
+        .withFailureHandler(err => {
+            orderSelect.innerHTML = '<option value="">-- Error Loading Orders --</option>';
+            showAlert("Failed to load welding orders: " + err);
+        })
+        .getWeldingOrders();
+
+      if (welderSteelModal) welderSteelModal.show();
+    }
+
+    function onWsCategoryChange() {
+      const cat = document.getElementById('wsCategorySelect').value;
+      const profSelect = document.getElementById('wsProfileSelect');
+      const customInput = document.getElementById('wsCustomProfile');
+      
+      customInput.classList.add('d-none');
+
+      if (!cat) {
+          profSelect.innerHTML = '<option value="">-- Select Category First --</option>';
+          return;
+      }
+      if (cat === 'Custom') {
+          profSelect.innerHTML = '<option value="__custom__">-- Enter Custom Profile --</option>';
+          customInput.classList.remove('d-none');
+          return;
+      }
+
+      const profiles = appData.steelProfiles.filter(p => p.category === cat);
+      let html = '<option value="">-- Choose Profile --</option>';
+      html += profiles.map(p => `<option value="${p.name}">${p.name}</option>`).join('');
+      html += '<option value="__custom__">+ Add Custom Profile</option>';
+
+      profSelect.innerHTML = html;
+    }
+
+    function onWsProfileChange() {
+      const val = document.getElementById('wsProfileSelect').value;
+      const customInput = document.getElementById('wsCustomProfile');
+      if (val === '__custom__') {
+          customInput.classList.remove('d-none');
+          customInput.focus();
+      } else {
+          customInput.classList.add('d-none');
+      }
+    }
+
+    function submitWelderSteel() {
+      if (isSubmitting) return;
+
+      const orderNum = document.getElementById('wsOrderSelect').value;
+      const workerName = document.getElementById('wsWorkerSelect').value;
+      const cat = document.getElementById('wsCategorySelect').value;
+      const profVal = document.getElementById('wsProfileSelect').value;
+      const customName = document.getElementById('wsCustomProfile').value.trim();
+      const size = document.getElementById('wsSizeInput').value.trim();
+      const unit = document.getElementById('wsUnitSelect').value;
+
+      if (!orderNum || !workerName || !cat || !profVal || !size) {
+          showAlert("Please complete all fields (Order, Welder, Category, Profile, and Size).");
+          return;
+      }
+
+      const isCustom = (profVal === '__custom__');
+      const finalName = isCustom ? customName : profVal;
+
+      if (isCustom && !finalName) {
+          showAlert("Please enter a custom profile name.");
+          return;
+      }
+
+      const steelItem = {
+          category: cat,
+          type: finalName,
+          size: size + " " + unit,
+          isCustom: isCustom
+      };
+
+      const btn = document.getElementById('btnSubmitWs');
+      const origText = btn.innerHTML;
+      isSubmitting = true;
+      btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span> LOGGING...';
+      btn.disabled = true;
+
+      google.script.run
+          .withSuccessHandler(res => {
+              isSubmitting = false;
+              btn.innerHTML = origText;
+              btn.disabled = false;
+              if(res.success) {
+                  if (welderSteelModal) welderSteelModal.hide();
+                  showAlert("Steel usage successfully logged for " + workerName + "!");
+              } else {
+                  showAlert("Error: " + res.error);
+              }
+          })
+          .withFailureHandler(err => {
+              isSubmitting = false;
+              btn.innerHTML = origText;
+              btn.disabled = false;
+              showAlert("Error: " + err);
+          })
+          .logWelderSteel(orderNum, workerName, steelItem);
+    }
+
+    async function submitQC(skip=false) {
+      if(isSubmitting) return; // Prevent double clicks
+      
+      let d = [], sig = '', fileData = [], dSteel = [];
+      const card = document.getElementById(`card-${session.pendingRow}`);
+
+      try {
+          if(!skip) {
+            // 1. GET THE EXACT LIST WE GENERATED EARLIER
+            const qcKey = session.currentQcKey || 'Profile Cutting';
+            const qs = QC_DATA[qcKey]; 
+            
+            // 2. VALIDATE ANSWERS
+            let allAnswered = true;
+            qs.forEach((q,i) => { 
+                const el = document.querySelector(`input[name="q${i}"]:checked`); 
+                if(!el) {
+                    allAnswered = false; 
+                } else {
+                    d.push({q:q, a:el.value}); 
+                }
+            });
+            
+            if(!allAnswered) { showAlert("Please answer all questions."); return; }
+            if(!hasSigned) { showAlert("Please sign before confirming."); return; } 
+            
+            sig = canvas.toDataURL();
+            
+            // 3. GATHER PHOTOS
+            const inputs = document.querySelectorAll('.photo-input');
+            // Check if all required photos are uploaded (optional ones can be skipped)
+            if(inputs.length > 0) {
+                let areAllRequiredPhotosUploaded = true;
+                for(let input of inputs) {
+                    const isOptional = input.dataset.optional === 'true';
+                    if(!isOptional && input.files.length === 0) {
+                        areAllRequiredPhotosUploaded = false;
+                        break;
+                    }
+                }
+                if(!areAllRequiredPhotosUploaded) { 
+                    showAlert("Please upload all required photos before confirming."); 
+                    return; 
+                }
+            }
+            
+            // Build photos array: include actual photo data or null for skipped optional photos
+            // This ensures array indices match the expected photo positions in the template
+            for(let input of inputs) {
+                if(input.files.length > 0) {
+                    let b64 = await toBase64(input.files[0]);
+                    fileData.push({
+                        name: input.files[0].name,
+                        mime: input.files[0].type,
+                        data: b64.split(',')[1] 
+                    });
+                } else {
+                    // Only optional photos should reach here due to validation above
+                    // Push null to maintain correct array indexing
+                    fileData.push(null);
+                }
+            }
+
+            // STEP 8: COLLECT AND VALIDATE MATERIAL ROWS (only when section is present)
+            const materialSection = document.getElementById('materialLoggingSection');
+            if (materialSection) {
+              const materialRows = document.querySelectorAll('#materialRowsContainer .material-row');
+              if (materialRows.length === 0) {
+                showAlert("Please add at least one steel profile or sheet used."); return;
+              }
+              let materialValid = true;
+              materialRows.forEach(rowEl => {
+                const type = rowEl.dataset.name;
+                const category = rowEl.dataset.category;
+                const size = rowEl.dataset.size;
+                const isCustom = rowEl.dataset.custom === 'true';
+
+                if (!type || !size) {
+                  materialValid = false;
+                } else {
+                  dSteel.push({ category: category, type: type, size: size, isCustom: isCustom });
+                }
+              });
+              if (!materialValid) {
+                showAlert("Invalid material row detected. Please check your entries."); return;
+              }
+            }
+          }
+          
+          // 4. UI FEEDBACK: SHOW LOADING STATE
+          isSubmitting = true;
+          if (qcModal) qcModal.hide();
+          
+          if(card) {
+             const btn = card.querySelector('button');
+             if(btn) {
+                 // Determine if PDF will be generated
+                 // PDFs are only generated for Quality Control or Final QC roles with QC data and signature
+                 const statusText = card.querySelector('.badge.bg-dark')?.innerText.toLowerCase().trim() || "";
+                 const willGeneratePdf = !skip && 
+                                       (session.role === 'Quality Control' || statusText === 'final qc') && 
+                                       statusText !== 'powder coating' &&
+                                       d.length > 0 && 
+                                       sig;
+                 
+                 // Change button text and add spinner
+                 const loadingText = willGeneratePdf ? 'UPLOADING PHOTOS...' : 'FINISHING...';
+                 btn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>' + loadingText;
+                 // Make it look grey/disabled
+                 btn.classList.remove('btn-success', 'btn-primary');
+                 btn.classList.add('btn-secondary');
+                 btn.disabled = true;
+             }
+             // Ensure opacity is full so you can read the loading text
+             card.style.opacity = '1';
+          }
+          
+          // 5. SEND TO SERVER
+          google.script.run
+            .withSuccessHandler((result) => { 
+              isSubmitting = false;
+              if(result && result.success === false) {
+                showAlert("Error: " + (result.error || "Unknown"));
+                // Reset button if error
+                if(card) {
+                    const btn = card.querySelector('button');
+                    if(btn) {
+                        btn.innerHTML = 'FINISH & QC';
+                        btn.classList.add('btn-success');
+                        btn.classList.remove('btn-secondary');
+                        btn.disabled = false;
+                    }
+                }
+              }
+              loadDashboard(true);
+            })
+            .withFailureHandler((error) => {
+              isSubmitting = false;
+              showAlert("Error: " + error);
+              // Reset button if error
+              if(card) {
+                  const btn = card.querySelector('button');
+                  if(btn) {
+                      btn.innerHTML = 'FINISH & QC';
+                      btn.classList.add('btn-success');
+                      btn.classList.remove('btn-secondary');
+                      btn.disabled = false;
+                  }
+              }
+              loadDashboard(true);
+            })
+            .finishOrder(session.pendingRow, (session.logIds && session.logIds[session.activeOrder]) || session.logId, d, sig, fileData, session.name, dSteel, session.activeOrder);
+
+      } catch (err) {
+          isSubmitting = false;
+          console.error(err);
+          showAlert("Error: " + err.message);
+          // Reset button if client error (like photo issue)
+          if(card) {
+              const btn = card.querySelector('button');
+              if(btn) {
+                  btn.disabled = false;
+              }
+          }
+      }
+    }
+
+    // UPGRADED: Resizes and compresses images before sending to server
+    function toBase64(file) {
+        return new Promise((resolve, reject) => {
+            const reader = new FileReader();
+            reader.readAsDataURL(file);
+            reader.onload = (event) => {
+                const img = new Image();
+                img.src = event.target.result;
+                img.onload = () => {
+                    const canvas = document.createElement('canvas');
+                    
+                    // 800px is perfectly sharp for an A4 PDF Document, but cuts file size by 90%
+                    const MAX_WIDTH = 800; 
+                    const MAX_HEIGHT = 800;
+                    let width = img.width;
+                    let height = img.height;
+
+                    if (width > height) {
+                        if (width > MAX_WIDTH) {
+                            height *= MAX_WIDTH / width;
+                            width = MAX_WIDTH;
+                        }
+                    } else {
+                        if (height > MAX_HEIGHT) {
+                            width *= MAX_HEIGHT / height;
+                            height = MAX_HEIGHT;
+                        }
+                    }
+                    
+                    canvas.width = width;
+                    canvas.height = height;
+                    const ctx = canvas.getContext('2d');
+                    ctx.drawImage(img, 0, 0, width, height);
+                    
+                    // Compress as JPEG at 70% quality (Unnoticeable quality loss, massive speed gain)
+                    resolve(canvas.toDataURL('image/jpeg', 0.7));
+                };
+                img.onerror = error => reject(error);
+            };
+            reader.onerror = error => reject(error);
+        });
+    }
+
+    function calculateWorkMinutes(startTs, endTs, taskName, pausedMins = 0, pauseStartTs = null) {
+      if (!startTs) return 0;
+      let start = new Date(parseInt(startTs));
+      let end = endTs ? new Date(parseInt(endTs)) : new Date();
+      
+      let rawMins = calcRawMins(start, end, taskName);
+      
+      let pMins = parseFloat(pausedMins) || 0;
+      if (pauseStartTs && !endTs) {
+         pMins += calcRawMins(new Date(parseInt(pauseStartTs)), end, taskName);
+      }
+      return Math.max(0, Math.floor(rawMins - pMins));
+    }
+
+    function calcRawMins(start, end, taskName) {
+      if (taskName && taskName.toLowerCase().trim() === 'powder coating') {
+        return (end - start) / 1000 / 60;
+      }
+      let totalMinutes = 0;
+      let current = new Date(start.getTime());
+      let safety = 0;
+      while (current < end && safety < 500) { 
+        safety++;
+        let day = current.getDay();
+        if (day === 0 || day === 6) {
+          current.setDate(current.getDate() + 1);
+          current.setHours(7, 30, 0, 0);
+          continue;
+        }
+        
+        let shiftStart = new Date(current); shiftStart.setHours(7, 30, 0, 0);
+        let lunchStart = new Date(current); lunchStart.setHours(12, 0, 0, 0);
+        let lunchEnd   = new Date(current); lunchEnd.setHours(13, 0, 0, 0);
+        let shiftEnd   = new Date(current); shiftEnd.setHours(15, 45, 0, 0);
+        
+        let windowStart = (current > shiftStart) ? current : shiftStart;
+        let windowEnd = (end < shiftEnd) ? end : shiftEnd;
+        
+        if (windowStart < windowEnd) {
+          let rawMins = (windowEnd - windowStart) / 1000 / 60;
+          let overlapStart = (windowStart > lunchStart) ? windowStart : lunchStart;
+          let overlapEnd = (windowEnd < lunchEnd) ? windowEnd : lunchEnd;
+          let lunchOverlap = (overlapStart < overlapEnd) ? (overlapEnd - overlapStart) / 1000 / 60 : 0;
+          
+          totalMinutes += (rawMins - lunchOverlap);
+        }
+        if (end < shiftEnd) break; 
+        else { 
+            current.setDate(current.getDate() + 1); 
+            current.setHours(7, 30, 0, 0); 
+        }
+      }
+      return totalMinutes;
+    }
+
+    function formatDuration(totalMins) {
+      let h = Math.floor(totalMins / 60);
+      let m = Math.floor(totalMins % 60);
+      return (h < 10 ? "0"+h : h) + ":" + (m < 10 ? "0"+m : m);
+    }
+
+    function startLiveTimers() {
+      if(liveTimerInterval) clearInterval(liveTimerInterval);
+      liveTimerInterval = setInterval(() => {
+        document.querySelectorAll('.live-timer').forEach(el => {
+          const start = parseInt(el.getAttribute('data-start'));
+          const task = el.getAttribute('data-task');
+          const pMins = parseFloat(el.getAttribute('data-pmins')) || 0;
+          const pStart = parseInt(el.getAttribute('data-pstart')) || null;
+          if(start) {
+            const mins = calculateWorkMinutes(start, null, task, pMins, pStart);
+            el.innerText = formatDuration(mins);
+          }
+        });
+      }, 1000); 
+    }
+
+    function loadProductionOverview() {
+      navTo('view-admin-prod');
+      const tabEl = document.querySelector('#adminProdTabs button[data-bs-target="#tab-notstarted"]');
+      if(tabEl) new bootstrap.Tab(tabEl).show();
+
+      document.getElementById('list-notstarted').innerHTML = '<div class="spinner-border"></div>';
+      document.getElementById('list-production').innerHTML = '<div class="spinner-border"></div>';
+      document.getElementById('list-delivery').innerHTML = '<div class="spinner-border"></div>';
+
+      google.script.run.withSuccessHandler(data => {
+        const rawLogs = data.logs;
+        const allOrders = data.orders;
+        const orderLogs = {};
+        
+        rawLogs.forEach(r => {
+          if (!orderLogs[r.order]) orderLogs[r.order] =[];
+          // Deduct paused time when calculating initial duration
+          r.durationMins = (typeof r.durationMins === 'number') ? r.durationMins : calculateWorkMinutes(r.start, r.end, r.task, r.pausedMins, r.pauseStart);
+          orderLogs[r.order].push(r);
+        });
+
+        let htmlNotStarted = '<div class="accordion">';
+        let htmlProd = '<div class="accordion">';
+        let htmlDeliv = '<div class="accordion">';
+
+        allOrders.forEach((o, i) => {
+          const status = String(o.status).toLowerCase();
+          const tasks = orderLogs[o.order] ||[];
+          const totalDuration = tasks.reduce((sum, t) => sum + t.durationMins, 0);
+          const totalTimeStr = formatDuration(totalDuration);
+          
+          // 1. Find exactly ONE active task (no end time)
+          const activeTask = tasks.find(t => !t.end);
+          const isRunning = !!activeTask;
+          const isPaused = activeTask ? !!activeTask.pauseStart : false;
+          
+          // 2. Button Logic: Only show buttons if there is an active task in the Prod tab
+          let actionBtn = '';
+          const isProdTab = !status.startsWith('not yet started') && !status.startsWith('out for') && !status.startsWith('delivered');
+          
+          if (isProdTab && isRunning) {
+              if (!isPaused) {
+                  actionBtn = `<button class="btn btn-sm btn-warning fw-bold border-dark shadow-sm ms-2" style="min-width: 85px;" onclick="event.stopPropagation(); adminTogglePause('${o.order}', 'pause', this)"><i class="bi bi-pause-fill"></i> PAUSE</button>`;
+              } else {
+                  actionBtn = `<button class="btn btn-sm btn-success fw-bold border-dark shadow-sm ms-2" style="min-width: 85px;" onclick="event.stopPropagation(); adminTogglePause('${o.order}', 'resume', this)"><i class="bi bi-play-fill"></i> RESUME</button>`;
+              }
+          }
+
+          // Header badge turns yellow if paused, green if actively running
+          let headerBadge = isRunning 
+                ? (isPaused ? '<span class="badge bg-warning text-dark me-2">Paused</span>' : '<span class="badge bg-success me-2">Active</span>') 
+                : '';
+
+          let item = `
+            <div class="card mb-2 shadow-sm">
+              <div class="card-header bg-white d-flex p-2 align-items-center">
+                <button class="btn btn-link text-decoration-none text-dark text-start flex-grow-1 d-flex justify-content-between align-items-center p-1 m-0" type="button" data-bs-toggle="collapse" data-bs-target="#ord-${i}">
+                  <div><strong>${o.order}</strong> <span class="badge bg-light text-dark border ms-2">${o.status}</span></div>
+                  <div>${headerBadge}<span class="badge bg-dark">${totalTimeStr}</span></div>
+                </button>
+                ${actionBtn}
+              </div>
+              <div id="ord-${i}" class="collapse">
+                <div class="card-body p-0">
+                  <div class="table-responsive">
+                    <table class="table table-sm mb-0">
+                      <thead>
+                        <tr><th>Worker</th><th>Task</th><th>Start</th><th>End</th><th>Duration</th><th>QC</th></tr>
+                      </thead>
+                      <tbody>`;
+          
+          if(tasks.length === 0) {
+            item += `<tr><td colspan="6" class="text-center text-muted py-3">No activity recorded yet.</td></tr>`;
+          } else {
+            tasks.forEach(t => {
+              const startDisplay = t.start ? new Date(t.start).toLocaleTimeString([], {hour:'2-digit', minute:'2-digit', second:'2-digit'}) : '-';
+              const endDisplay = t.end ? new Date(t.end).toLocaleTimeString([], {hour:'2-digit', minute:'2-digit', second:'2-digit'}) : '-';
+              let durDisplay = formatDuration(t.durationMins);
+              
+              // If task is not ended, handle Live Timer vs Paused State
+              if(!t.end) {
+                  if (t.pauseStart) {
+                      // It is currently paused, so show a static yellow badge
+                      durDisplay = `<span class="badge bg-warning text-dark">Paused (${durDisplay})</span>`;
+                  } else {
+                      // It is running, show the live ticking green badge
+                      durDisplay = `<span class="badge bg-success live-timer" data-start="${t.start}" data-task="${t.task}" data-pmins="${t.pausedMins || 0}" data-pstart="${t.pauseStart || ''}">${durDisplay}</span>`;
+                  }
+              }
+              
+              const qcIcon = t.qc && t.qc !== 'Skipped' ? '<i class="bi bi-check-circle-fill text-success"></i>' : '-';
+              item += `<tr><td>${t.worker}</td><td>${t.task}</td><td>${startDisplay}</td><td>${endDisplay}</td><td>${durDisplay}</td><td>${qcIcon}</td></tr>`;
+            });
+          }
+          item += `</tbody></table></div></div></div></div>`;
+
+          if (status.startsWith('not yet started')) htmlNotStarted += item;
+          else if (status.startsWith('out for') || status.startsWith('delivered')) htmlDeliv += item;
+          else htmlProd += item;
+        });
+
+        htmlNotStarted += '</div>'; htmlProd += '</div>'; htmlDeliv += '</div>';
+        document.getElementById('list-notstarted').innerHTML = htmlNotStarted || '<p class="text-muted">Empty</p>';
+        document.getElementById('list-production').innerHTML = htmlProd || '<p class="text-muted">Empty</p>';
+        document.getElementById('list-delivery').innerHTML = htmlDeliv || '<p class="text-muted">Empty</p>';
+        filterProduction();
+      }).getAdminDashboardData();
+    }
+
+    function adminTogglePause(orderNum, action, btnEl) {
+        if(event) event.stopPropagation(); 
+        
+        const isPause = action === 'pause';
+        const originalHtml = btnEl.innerHTML;
+        btnEl.innerHTML = '<span class="spinner-border spinner-border-sm"></span>...';
+        btnEl.disabled = true;
+
+        const targetFunction = isPause ? 'adminPauseOrder' : 'adminResumeOrder';
+
+        google.script.run
+            .withSuccessHandler(res => {
+                if(res.success) {
+                    loadProductionOverview(); // Reload the admin view to show changes
+                } else {
+                    showAlert(res.message || "Action failed.");
+                    btnEl.innerHTML = originalHtml;
+                    btnEl.disabled = false;
+                }
+            })
+            .withFailureHandler(err => {
+                showAlert("System Error: " + err);
+                btnEl.innerHTML = originalHtml;
+                btnEl.disabled = false;
+            })
+            [targetFunction](orderNum);
+    }
+
+    function setActiveWorker(el) {
+      document.querySelectorAll('#workerSelect_List .worker-card').forEach(btn => btn.classList.remove('active'));
+      el.classList.add('active');
+    }
+
+    function loadWorkerStats() {
+      navTo('view-admin-workers');
+      loadIdleWorkers();
+      document.getElementById('workerSelect_List').innerHTML = '<div class="spinner-border spinner-border-sm"></div>';
+      google.script.run.withSuccessHandler(data => {
+        const rawLogs = data.logs;
+        appData.workerStats = {};
+        
+        // --- NEW: Calculate Changeover Times (Intelligent Day/Overlap Logic) ---
+        // 1. Group logs by worker
+        let workerLogsMap = {};
+        rawLogs.forEach(r => {
+          if(!r.worker) return;
+          if(!workerLogsMap[r.worker]) workerLogsMap[r.worker] = [];
+          workerLogsMap[r.worker].push(r);
+        });
+
+        // 2. Sort chronologically and compute gaps safely
+        Object.keys(workerLogsMap).forEach(worker => {
+           let wLogs = workerLogsMap[worker];
+           wLogs.sort((a,b) => (a.start || 0) - (b.start || 0));
+           
+           let maxEndBefore = null;
+           wLogs.forEach(r => {
+              r.changeoverMins = 0;
+              r.isChangeoverTracked = false;
+              
+              if (r.start) {
+                  if (maxEndBefore) {
+                      if (r.start <= maxEndBefore) {
+                          // Overlapping / Parallel task -> Perfect 0 min changeover
+                          r.isChangeoverTracked = true;
+                          r.changeoverMins = 0;
+                      } else {
+                          // Gap exists. Calculates working time, automatically skipping nights, weekends & lunch.
+                          r.isChangeoverTracked = true;
+                          r.changeoverMins = calculateWorkMinutes(maxEndBefore, r.start, 'Changeover');
+                          
+                          // Safeguard: If gap >= 435 mins (full shift length), assume worker was absent.
+                          if (r.changeoverMins >= 435) {
+                              r.changeoverMins = 0;
+                              r.isChangeoverTracked = false;
+                          }
+                      }
+                  } else {
+                      // First task ever recorded for this worker
+                      r.isChangeoverTracked = false;
+                  }
+              }
+              
+              // Safely update the latest known end time 
+              let currentEnd = r.end ? r.end : new Date().getTime();
+              if (!maxEndBefore || currentEnd > maxEndBefore) {
+                  maxEndBefore = currentEnd;
+              }
+           });
+        });
+
+        // 3. Build Stats
+        rawLogs.forEach(r => {
+          if(!r.worker) return;
+          if(!appData.workerStats[r.worker]) appData.workerStats[r.worker] = { totalMins: 0, weeks: {} };
+          const dur = calculateWorkMinutes(r.start, r.end, r.task, r.pausedMins, r.pauseStart);
+          appData.workerStats[r.worker].totalMins += dur;
+          r.durationMins = dur;
+          
+          // Group into weekly buckets
+          const weekKey = r.week || 'Unknown Week';
+          if(!appData.workerStats[r.worker].weeks[weekKey]) {
+            appData.workerStats[r.worker].weeks[weekKey] = { 
+              totalMins: 0, 
+              logs:[], 
+              uniqueOrders: new Set(),
+              totalChangeoverMins: 0,
+              changeoverCount: 0 
+            };
+          }
+          
+          appData.workerStats[r.worker].weeks[weekKey].totalMins += dur;
+          appData.workerStats[r.worker].weeks[weekKey].logs.push(r);
+          if(r.order) appData.workerStats[r.worker].weeks[weekKey].uniqueOrders.add(r.order);
+          
+          // Apply changeover stats (Even if it is 0, to reward efficiency)
+          if (r.isChangeoverTracked) {
+              appData.workerStats[r.worker].weeks[weekKey].totalChangeoverMins += r.changeoverMins;
+              appData.workerStats[r.worker].weeks[weekKey].changeoverCount += 1;
+          }
+        });
+
+        let h = '';
+        Object.keys(appData.workerStats).sort().forEach(name => {
+          const w = appData.workerStats[name];
+          const initial = name.trim().charAt(0).toUpperCase();
+          h += `<button class="worker-card" data-worker-name="${name}" onclick="setActiveWorker(this); showWorkerDetail('${name}')">
+            <div class="avatar-circle">${initial}</div>
+            <span class="worker-name">${name}</span>
+            <span class="worker-hours">${formatDuration(w.totalMins)}</span>
+          </button>`;
+        });
+        document.getElementById('workerSelect_List').innerHTML = h;
+
+        // Collect all unique weeks across all workers for the comparison dropdown
+        const allWeeksSet = new Set();
+        Object.values(appData.workerStats).forEach(w => {
+          Object.keys(w.weeks).forEach(wk => allWeeksSet.add(wk));
+        });
+        const allWeeksSorted = Array.from(allWeeksSet).sort().reverse();
+        const weekFilterEl = document.getElementById('globalCompareWeekFilter');
+        if (weekFilterEl) {
+          weekFilterEl.innerHTML = allWeeksSorted.map((wk, idx) =>
+            `<option value="${wk}" ${idx === 0 ? 'selected' : ''}>${wk}</option>`
+          ).join('');
+        }
+
+        // Populate the worker filter dropdown with one checked checkbox per worker
+        const sortedWorkerNames = Object.keys(appData.workerStats).sort();
+        const workerFilterList = document.getElementById('compareWorkerFilterList');
+        const workerFilterBtn = document.getElementById('compareWorkerFilterBtn');
+        if (workerFilterList) {
+          workerFilterList.innerHTML = sortedWorkerNames.map(name =>
+            `<li>
+              <label class="dropdown-item d-flex align-items-center gap-2 py-1 px-2" style="cursor:pointer;">
+                <input type="checkbox" class="compare-worker-cb form-check-input mt-0 flex-shrink-0"
+                  value="${name}" checked onchange="renderWorkerComparison()">
+                <span>${name}</span>
+              </label>
+            </li>`
+          ).join('');
+        }
+        if (workerFilterBtn) {
+          workerFilterBtn.disabled = false;
+          workerFilterBtn.querySelector('span').textContent = `All ${sortedWorkerNames.length} Workers`;
+        }
+
+        renderWorkerComparison();
+      }).getAdminDashboardData();
+    }
+
+    function renderWorkerComparison() {
+      const selectedWeek = document.getElementById('globalCompareWeekFilter')?.value;
+      if (!selectedWeek || Object.keys(appData.workerStats).length === 0) return;
+
+      // STEP 3: Read checked worker checkboxes to build the selected workers list
+      const checkedBoxes = document.querySelectorAll('#compareWorkerFilterList .compare-worker-cb:checked');
+      const selectedWorkers = Array.from(checkedBoxes).map(cb => cb.value);
+
+      // Update the dropdown button label to reflect current selection
+      const workerFilterBtn = document.getElementById('compareWorkerFilterBtn');
+      const totalWorkers = document.querySelectorAll('#compareWorkerFilterList .compare-worker-cb').length;
+      if (workerFilterBtn) {
+        const btnSpan = workerFilterBtn.querySelector('span');
+        if (btnSpan) {
+          btnSpan.textContent = selectedWorkers.length === totalWorkers
+            ? `All ${totalWorkers} Workers`
+            : `${selectedWorkers.length} of ${totalWorkers} Selected`;
+        }
+      }
+
+      if (selectedWorkers.length === 0) {
+        if (comparisonChart) { comparisonChart.destroy(); comparisonChart = null; }
+        document.getElementById('workerComparisonTableContainer').innerHTML =
+          `<div class="text-center py-4 text-muted"><i class="bi bi-person-x" style="font-size:2rem;opacity:0.4;"></i><p class="mt-2">No workers selected. Check at least one worker above.</p></div>`;
+        return;
+      }
+
+      // Build workerData: for each selected worker, compute totalMins and a per-order breakdown
+      // All unique orders encountered are tracked in a Set
+      const allOrdersSet = new Set();
+      const UNASSIGNED_LABEL = 'General / Unassigned';
+
+      const workerData = selectedWorkers.map(workerName => {
+        const weekBucket = appData.workerStats[workerName]?.weeks[selectedWeek];
+        if (!weekBucket) {
+          return { workerName, totalMins: 0, orderMins: {} };
+        }
+        const orderMins = {};
+        weekBucket.logs.forEach(log => {
+          const orderKey = (log.order && String(log.order).trim()) ? String(log.order).trim() : UNASSIGNED_LABEL;
+          allOrdersSet.add(orderKey);
+          orderMins[orderKey] = (orderMins[orderKey] || 0) + (log.durationMins || 0);
+        });
+        return { workerName, totalMins: weekBucket.totalMins, orderMins, orderCount: weekBucket.uniqueOrders.size };
+      });
+
+      // STEP 4: Sort descending by totalMins for X-axis ordering
+      workerData.sort((a, b) => b.totalMins - a.totalMins);
+      const labels = workerData.map(d => d.workerName);
+
+      // Extended colour palette — one colour per unique order
+      const palette = [
+        '#1a1a1a', '#198754', '#0d6efd', '#dc3545', '#fd7e14',
+        '#6f42c1', '#20c997', '#0dcaf0', '#ffc107', '#d63384',
+        '#adb5bd', '#795548', '#009688', '#e91e63', '#3f51b5',
+        '#ff5722', '#4caf50', '#607d8b', '#ff9800', '#9c27b0'
+      ];
+
+      // Convert the set of orders to a sorted array; put UNASSIGNED last if present
+      const allOrders = Array.from(allOrdersSet).sort((a, b) => {
+        if (a === UNASSIGNED_LABEL) return 1;
+        if (b === UNASSIGNED_LABEL) return -1;
+        return a.localeCompare(b);
+      });
+
+      // Build one dataset per unique order
+      const datasets = allOrders.map((order, i) => ({
+        label: order,
+        data: workerData.map(d => {
+          const mins = d.orderMins[order] || 0;
+          return parseFloat((mins / 60).toFixed(4));
+        }),
+        backgroundColor: palette[i % palette.length],
+        borderRadius: 3,
+        borderSkipped: false,
+        // Store raw mins for tooltip
+        _rawMins: workerData.map(d => d.orderMins[order] || 0)
+      }));
+
+      const ctx = document.getElementById('workerComparisonChart')?.getContext('2d');
+      if (!ctx) return;
+
+      // Destroy previous chart instance
+      if (comparisonChart) { comparisonChart.destroy(); comparisonChart = null; }
+
+      comparisonChart = new Chart(ctx, {
+        type: 'bar',
+        data: { labels, datasets },
+        options: {
+          responsive: true,
+          plugins: {
+            legend: {
+              display: true,
+              position: 'bottom',
+              labels: { boxWidth: 14, padding: 12, font: { size: 11 } }
+            },
+            tooltip: {
+              callbacks: {
+                label: function(context) {
+                  const rawMins = context.dataset._rawMins?.[context.dataIndex] ?? 0;
+                  if (rawMins === 0) return null; // hide zero-value segments
+                  return ` ${context.dataset.label}: ${formatDuration(rawMins)}`;
+                }
+              }
+            }
+          },
+          scales: {
+            x: { stacked: true, grid: { display: false } },
+            y: {
+              stacked: true,
+              beginAtZero: true,
+              title: { display: true, text: 'Hours', font: { weight: 'bold' } },
+              ticks: { callback: v => v + 'h' }
+            }
+          }
+        }
+      });
+
+      // STEP 5: Ranked table — reflects filtered workers only, sorted by totalMins desc
+      let tableHtml = `
+        <div class="modern-table-wrap">
+          <table class="modern-table" id="workerComparisonTable">
+            <thead>
+              <tr><th>#</th><th>Worker</th><th style="text-align:center">Orders</th><th style="text-align:right">Total Hours</th></tr>
+            </thead>
+            <tbody>`;
+      workerData.forEach((d, idx) => {
+        const zeroStyle = d.totalMins === 0 ? ' style="opacity:0.45;"' : '';
+        tableHtml += `<tr${zeroStyle}>
+          <td><strong>${idx + 1}</strong></td>
+          <td>
+            <div class="d-flex align-items-center gap-2">
+              <div class="avatar-circle" style="width:28px;height:28px;font-size:0.75rem;background:${palette[idx % palette.length]}">${d.workerName.charAt(0).toUpperCase()}</div>
+              ${d.workerName}
+            </div>
+          </td>
+          <td style="text-align:center">${d.orderCount > 0 ? `<span class="badge" style="background:#6f42c1">${d.orderCount}</span>` : '<span class="text-muted">—</span>'}</td>
+          <td style="text-align:right">${d.totalMins > 0 ? formatDuration(d.totalMins) : '<span class="text-muted">—</span>'}</td>
+        </tr>`;
+      });
+      tableHtml += '</tbody></table></div>';
+      document.getElementById('workerComparisonTableContainer').innerHTML = tableHtml;
+    }
+
+    function showWorkerDetail(name) {
+      const w = appData.workerStats[name];
+      // Sort weeks descending (newest first)
+      const sortedWeeks = Object.keys(w.weeks).sort().reverse();
+      let weekOptions = sortedWeeks.map((wk, idx) => `<option value="${wk}" ${idx === 0 ? 'selected' : ''}>${wk}</option>`).join('');
+      const initial = name.trim().charAt(0).toUpperCase();
+
+      let h = `
+        <div class="d-flex align-items-center gap-3 mb-4 pb-3 border-bottom">
+          <div class="avatar-circle lg">${initial}</div>
+          <div class="flex-grow-1">
+            <h3 class="brand-font mb-0">${name}</h3>
+            <small class="text-muted">All-time:</small>
+            <span class="badge bg-dark ms-1 fs-6">${formatDuration(w.totalMins)}</span>
+          </div>
+        </div>
+        <div class="row g-2 mb-3">
+          <div class="col-md-6">
+            <label class="form-label small fw-bold text-uppercase text-muted mb-1">Filter by Week</label>
+            <select id="weekFilter" class="form-select" onchange="renderWorkerWeekDetail('${name}')">${weekOptions}</select>
+          </div>
+          <div class="col-md-6">
+            <label class="form-label small fw-bold text-uppercase text-muted mb-1">Search Order #</label>
+            <input type="text" id="workerLogSearch" class="form-control" placeholder="e.g. SD-123" onkeyup="filterWorkerLogs()">
+          </div>
+        </div>
+        <div id="workerWeekContent"></div>`;
+      document.getElementById('workerDetailContent').innerHTML = h;
+      // Populate the table immediately with the most recent week
+      renderWorkerWeekDetail(name);
+    }
+
+    function renderWorkerWeekDetail(workerName) {
+      const selectedWeek = document.getElementById('weekFilter').value;
+      const weekData = appData.workerStats[workerName].weeks[selectedWeek];
+
+      if (!weekData) {
+        document.getElementById('workerWeekContent').innerHTML = `
+          <div class="text-center py-5 text-muted">
+            <i class="bi bi-calendar-x" style="font-size:2.5rem; opacity:0.4;"></i>
+            <p class="mt-3 mb-0 fw-bold">No activity recorded for this week.</p>
+            <small>Try selecting a different week from the dropdown above.</small>
+          </div>`;
+        return;
+      }
+
+      const avgMins = weekData.uniqueOrders.size > 0 ? weekData.totalMins / weekData.uniqueOrders.size : 0;
+      const avgChangeoverMins = weekData.changeoverCount > 0 ? weekData.totalChangeoverMins / weekData.changeoverCount : 0;
+
+      let h = `<div class="row g-3 mb-4">
+        <div class="col-6 col-md-3">
+          <div class="stat-card primary">
+            <i class="bi bi-clock-history stat-icon"></i>
+            <div class="stat-label">Total Hours</div>
+            <div class="stat-value">${formatDuration(weekData.totalMins)}</div>
+          </div>
+        </div>
+        <div class="col-6 col-md-3">
+          <div class="stat-card success">
+            <i class="bi bi-speedometer2 stat-icon"></i>
+            <div class="stat-label">Avg / Order</div>
+            <div class="stat-value">${formatDuration(avgMins)}</div>
+          </div>
+        </div>
+        <div class="col-6 col-md-3">
+          <div class="stat-card" style="border-color:#f0f0f0;">
+            <i class="bi bi-arrow-left-right stat-icon" style="color:#fd7e14;"></i>
+            <div class="stat-label" style="color:#888;">Avg Changeover</div>
+            <div class="stat-value" style="color:#fd7e14;">${formatDuration(avgChangeoverMins)}</div>
+          </div>
+        </div>
+        <div class="col-6 col-md-3">
+          <div class="stat-card" style="border-color:#f0f0f0;">
+            <i class="bi bi-bag-check stat-icon" style="color:#6f42c1;"></i>
+            <div class="stat-label" style="color:#888;">Completed</div>
+            <div class="stat-value" style="color:#6f42c1;">${weekData.uniqueOrders.size}</div>
+          </div>
+        </div>
+      </div>`;
+
+      h += '<div class="modern-table-wrap"><table class="modern-table" id="workerLogTable"><thead><tr><th>Date</th><th>Order</th><th>Task</th><th>Start</th><th>End</th><th style="text-align:right">Duration</th></tr></thead><tbody>';
+
+      weekData.logs.sort((a, b) => b.start - a.start).forEach(l => {
+        const d = l.start ? new Date(l.start).toLocaleDateString() : '-';
+        const s = l.start ? new Date(l.start).toLocaleTimeString([], {hour:'2-digit', minute:'2-digit', second:'2-digit'}) : '-';
+        const e = l.end ? new Date(l.end).toLocaleTimeString([], {hour:'2-digit', minute:'2-digit', second:'2-digit'}) : '<span class="badge bg-success">Running</span>';
+        let durDisplay = formatDuration(l.durationMins);
+        if(!l.end) durDisplay = `<span class="badge bg-success live-timer" data-start="${l.start}" data-task="${l.task}" data-pmins="${l.pausedMins || 0}" data-pstart="${l.pauseStart || ''}">${durDisplay}</span>`;
+        h += `<tr data-order="${String(l.order).toLowerCase()}"><td>${d}</td><td><strong>${l.order}</strong></td><td>${l.task}</td><td>${s}</td><td>${e}</td><td style="text-align:right">${durDisplay}</td></tr>`;
+      });
+
+      h += '</tbody></table></div>';
+      document.getElementById('workerWeekContent').innerHTML = h;
+    }
+
+    function filterWorkerLogs() {
+      const search = (document.getElementById('workerLogSearch')?.value || '').toLowerCase();
+      const table = document.getElementById('workerLogTable');
+      if (!table) return;
+      const rows = table.getElementsByTagName('tbody')[0].getElementsByTagName('tr');
+      for (let i = 0; i < rows.length; i++) {
+        const orderVal = rows[i].getAttribute('data-order') || '';
+        rows[i].style.display = orderVal.includes(search) ? '' : 'none';
+      }
+    }
+
+
+    function loadMetricsDashboard() {
+      navTo('view-admin-metrics');
+      loadOrderOverview();
+      // Note: Production trends will be loaded when user switches to that tab
+    }
+    
+    // Order Overview Tab Functions
+    let orderOverviewData = null;
+
+    function loadOrderOverview() {
+      document.getElementById('orderOverviewContainer').innerHTML = '<div class="text-center p-5"><div class="spinner-border"></div></div>';
+      
+      google.script.run.withSuccessHandler(data => {
+        orderOverviewData = data;
+        
+        if (!data || !data.orders || data.orders.length === 0) {
+          document.getElementById('orderOverviewContainer').innerHTML = '<div class="text-center p-5 text-muted">No data available. Ensure orders have been tracked in the Production Log.</div>';
+          return;
+        }
+
+        const weekFilter = document.getElementById('overviewWeekFilter');
+        if(weekFilter) {
+          const currentVal = weekFilter.value; 
+          weekFilter.innerHTML = '<option value="">All Weeks</option>';
+          if(data.weeks) {
+            data.weeks.forEach(week => {
+              const selected = (week === currentVal) ? 'selected' : '';
+              weekFilter.innerHTML += `<option value="${week}" ${selected}>${week}</option>`;
+            });
+          }
+        }
+
+        // Populate product name filter
+        const productFilter = document.getElementById('overviewProductFilter');
+        if(productFilter) {
+          const currentProductVal = productFilter.value;
+          const uniqueProducts = [...new Set(
+            data.orders.map(o => o.productName || 'Unknown').filter(p => p)
+          )].sort();
+          productFilter.innerHTML = '<option value="">All Products</option>';
+          uniqueProducts.forEach(product => {
+            const selected = (product === currentProductVal) ? 'selected' : '';
+            productFilter.innerHTML += `<option value="${product}" ${selected}>${product}</option>`;
+          });
+        }
+        
+        filterOrderMetrics(); // Rebuilds table dynamically
+      }).getOrderMetrics();
+    }
+    
+    function filterOrderMetrics() {
+      if (!orderOverviewData) return;
+      
+      const search = document.getElementById('orderSearch') ? document.getElementById('orderSearch').value.toLowerCase() : "";
+      const selectedWeek = document.getElementById('overviewWeekFilter') ? document.getElementById('overviewWeekFilter').value : "";
+      const selectedProduct = document.getElementById('overviewProductFilter') ? document.getElementById('overviewProductFilter').value : "";
+      
+      let html = '<div class="table-responsive"><table class="table table-hover table-sm mb-0" id="orderMetricsTable"><thead class="table-dark"><tr>';
+      html += '<th class="sticky-col">Order #</th>';
+      html += '<th class="sticky-col-2">Product Name</th>';
+      
+      orderOverviewData.processes.forEach(process => {
+        html += `<th colspan="2" class="text-center border-start">${process}</th>`;
+      });
+      html += '<th colspan="2" class="text-center border-start bg-secondary">Total</th>';
+      html += '</tr><tr>';
+      html += '<th class="sticky-col"></th>';
+      html += '<th class="sticky-col-2"></th>';
+      
+      orderOverviewData.processes.forEach(() => {
+        html += '<th class="text-end small border-start">Time</th><th class="text-end small">Cost</th>';
+      });
+      html += '<th class="text-end small border-start bg-secondary">Time</th><th class="text-end small bg-secondary">Cost</th>';
+      html += '</tr></thead><tbody>';
+      
+      let sortedOrders = [...orderOverviewData.orders].sort((a, b) => a.orderNum.localeCompare(b.orderNum));
+      let rowsAdded = 0;
+      
+      sortedOrders.forEach(order => {
+        const orderNumLower = order.orderNum.toLowerCase();
+        if (search && !orderNumLower.includes(search)) return;
+        if (selectedProduct && (order.productName || 'Unknown') !== selectedProduct) return;
+        
+        let orderTotalTime = 0;
+        let orderTotalCost = 0;
+        let rowHtml = `<tr>`;
+        rowHtml += `<td class="sticky-col"><strong>${order.orderNum}</strong></td>`;
+        rowHtml += `<td class="sticky-col-2">${order.productName || 'Unknown'}</td>`;
+        
+        let hasDataInSelection = false;
+        
+        orderOverviewData.processes.forEach(process => {
+          const processData = order.processes[process];
+          let pTime = 0; let pCost = 0;
+          
+          if (processData) {
+             if (selectedWeek === "") {
+                pTime = processData.totalMinutes;
+                pCost = processData.totalCost;
+             } else if (processData.weeklyData && processData.weeklyData[selectedWeek]) {
+                pTime = processData.weeklyData[selectedWeek].minutes;
+                pCost = processData.weeklyData[selectedWeek].cost;
+             }
+          }
+          
+          if (pTime > 0) {
+            hasDataInSelection = true;
+            orderTotalTime += pTime;
+            orderTotalCost += pCost;
+            rowHtml += `<td class="text-end border-start">${formatDuration(pTime)}</td>`;
+            rowHtml += `<td class="text-end">R ${pCost.toFixed(2)}</td>`;
+          } else {
+            rowHtml += '<td class="text-end text-muted border-start">-</td><td class="text-end text-muted">-</td>';
+          }
+        });
+        
+        rowHtml += `<td class="text-end fw-bold border-start bg-light">${formatDuration(orderTotalTime)}</td>`;
+        rowHtml += `<td class="text-end fw-bold bg-light">R ${orderTotalCost.toFixed(2)}</td>`;
+        rowHtml += '</tr>';
+        
+        // ONLY render the order row if it actually had work done during the selected week
+        if (hasDataInSelection) {
+           html += rowHtml;
+           rowsAdded++;
+        }
+      });
+      
+      if(rowsAdded === 0) {
+         html += `<tr><td colspan="${orderOverviewData.processes.length * 2 + 4}" class="text-center py-4 text-muted">No orders found matching the selected week and search criteria.</td></tr>`;
+      }
+      
+      html += '</tbody></table></div>';
+      document.getElementById('orderOverviewContainer').innerHTML = html;
+    }
+    
+    // Production Trends Tab Functions
+    let productionTrendsChart = null;
+    let productionTrendsData = null;
+    
+    function loadProductionTrends() {
+      const canvas = document.getElementById('productionTrendsChart');
+      const ctx = canvas.getContext('2d');
+      if (productionTrendsChart) { productionTrendsChart.destroy(); productionTrendsChart = null; }
+      
+      const orderFilterBtn = document.getElementById('orderFilterBtn');
+      if(orderFilterBtn) {
+        orderFilterBtn.disabled = true;
+        orderFilterBtn.querySelector('span').innerText = 'Select Product First';
+      }
+      
+      google.script.run.withSuccessHandler(data => {
+        productionTrendsData = data;
+        
+        if (!data || !data.products || data.products.length === 0) {
+          ctx.clearRect(0, 0, canvas.width, canvas.height);
+          ctx.font = '16px Arial'; ctx.fillStyle = '#999'; ctx.textAlign = 'center';
+          ctx.fillText('No data available', canvas.width / 2, canvas.height / 2);
+          return;
+        }
+        
+        const productFilter = document.getElementById('productFilter');
+        productFilter.innerHTML = '<option value="">All Products</option>';
+        data.products.forEach(product => productFilter.innerHTML += `<option value="${product}">${product}</option>`);
+        
+        const weekFilter = document.getElementById('trendWeekFilter');
+        weekFilter.innerHTML = '<option value="">All Weeks</option>';
+        if(data.weeks) {
+          data.weeks.forEach(week => weekFilter.innerHTML += `<option value="${week}">${week}</option>`);
+        }
+        
+        renderProductionTrendsChart('', '');
+      }).getProductionTrendsData();
+    }
+    
+    function filterProductionTrends() {
+      const selectedWeek = document.getElementById('trendWeekFilter').value;
+      const selectedProduct = document.getElementById('productFilter').value;
+      const orderFilterBtn = document.getElementById('orderFilterBtn');
+      const orderFilterList = document.getElementById('orderFilterList');
+      
+      if (!selectedProduct) {
+        orderFilterBtn.disabled = true;
+        orderFilterBtn.querySelector('span').innerText = 'Select Product First';
+        orderFilterList.innerHTML = '<li><span class="text-muted small px-2">Select a product to view orders.</span></li>';
+        renderProductionTrendsChart(selectedProduct, selectedWeek, null);
+        return;
+      }
+
+      orderFilterBtn.disabled = false;
+      orderFilterBtn.querySelector('span').innerText = 'All Orders Selected';
+      orderFilterList.innerHTML = '';
+      
+      let ordersForProduct = productionTrendsData.orderData.filter(o => o.productName === selectedProduct);
+      
+      // Filter out orders that had 0 time tracked in the selected week so they don't clog the dropdown
+      if (selectedWeek) {
+        ordersForProduct = ordersForProduct.filter(o => {
+          let hasActivity = false;
+          for (let p in o.processes) {
+             if (o.processes[p].weeklyData && o.processes[p].weeklyData[selectedWeek] && o.processes[p].weeklyData[selectedWeek].minutes > 0) {
+                 hasActivity = true;
+                 break;
+             }
+          }
+          return hasActivity;
+        });
+      }
+      
+      orderFilterList.innerHTML += `
+        <li>
+          <div class="form-check px-3 border-bottom pb-2 mb-2 mt-1">
+            <input class="form-check-input border-dark" type="checkbox" id="selectAllOrdersChk" checked onchange="toggleAllOrders(this)">
+            <label class="form-check-label fw-bold" for="selectAllOrdersChk">Select All Orders</label>
+          </div>
+        </li>
+      `;
+
+      ordersForProduct.forEach(o => {
+        orderFilterList.innerHTML += `
+          <li>
+            <div class="form-check px-3 py-1">
+              <input class="form-check-input border-dark order-filter-chk" type="checkbox" value="${o.orderNum}" checked onchange="updateSpecificOrderFilter()">
+              <label class="form-check-label text-dark">${o.orderNum}</label>
+            </div>
+          </li>
+        `;
+      });
+
+      renderProductionTrendsChart(selectedProduct, selectedWeek, null);
+    }
+    
+    function toggleAllOrders(masterChk) {
+      const checkboxes = document.querySelectorAll('.order-filter-chk');
+      checkboxes.forEach(chk => chk.checked = masterChk.checked);
+      updateSpecificOrderFilter();
+    }
+
+    function updateSpecificOrderFilter() {
+      const selectedProduct = document.getElementById('productFilter').value;
+      const selectedWeek = document.getElementById('trendWeekFilter').value;
+      const checkboxes = document.querySelectorAll('.order-filter-chk');
+      const selectedOrders = Array.from(checkboxes).filter(chk => chk.checked).map(chk => chk.value);
+      
+      const masterChk = document.getElementById('selectAllOrdersChk');
+      if (masterChk) masterChk.checked = (selectedOrders.length === checkboxes.length);
+
+      const btnSpan = document.querySelector('#orderFilterBtn span');
+      if (selectedOrders.length === checkboxes.length) btnSpan.innerText = 'All Orders Selected';
+      else if (selectedOrders.length === 0) btnSpan.innerText = 'No Orders Selected';
+      else btnSpan.innerText = `${selectedOrders.length} Orders Selected`;
+
+      renderProductionTrendsChart(selectedProduct, selectedWeek, selectedOrders);
+    }
+
+    function renderProductionTrendsChart(filterProduct, filterWeek, selectedOrdersArray = null) {
+      if (!productionTrendsData) return;
+      
+      const canvas = document.getElementById('productionTrendsChart');
+      const ctx = canvas.getContext('2d');
+      if (productionTrendsChart) productionTrendsChart.destroy();
+      
+      let filteredData = productionTrendsData.orderData;
+      
+      if (filterProduct) {
+        filteredData = filteredData.filter(order => order.productName === filterProduct);
+      }
+      if (selectedOrdersArray !== null) {
+        filteredData = filteredData.filter(order => selectedOrdersArray.includes(order.orderNum));
+      }
+      
+      const excludedProcesses =['Powder Coating', 'Out for Delivery'];
+      const graphProcesses = productionTrendsData.processes.filter(p => !excludedProcesses.includes(p));
+      
+      const datasets = [];
+      const colorPalette =['#FF6384', '#36A2EB', '#FFCE56', '#4BC0C0', '#9966FF', '#FF9F40', '#FF6384', '#C9CBCF', '#4BC0C0', '#FF6384'];
+      let hasAnyData = false;
+
+      filteredData.forEach((order, idx) => {
+        const dataPoints =[];
+        let orderHasDataInSelection = false;
+        
+        graphProcesses.forEach(process => {
+          const processData = order.processes[process];
+          let pTime = 0; let pCost = 0; let pWorkers = 'N/A';
+          
+          if (processData) {
+             if (filterWeek === "") {
+                pTime = processData.totalMinutes;
+                pCost = processData.totalCost;
+                pWorkers = processData.workers.join(', ');
+             } else if (processData.weeklyData && processData.weeklyData[filterWeek]) {
+                pTime = processData.weeklyData[filterWeek].minutes;
+                pCost = processData.weeklyData[filterWeek].cost;
+                pWorkers = processData.weeklyData[filterWeek].workers.join(', ');
+             }
+          }
+          
+          if (pTime > 0) orderHasDataInSelection = true;
+
+          dataPoints.push({ x: process, y: pTime, worker: pWorkers, cost: pCost });
+        });
+        
+        // Only map the line if work occurred during the selected filter
+        if (orderHasDataInSelection) {
+            hasAnyData = true;
+            datasets.push({
+              label: `${order.orderNum} - ${order.productName}`,
+              data: dataPoints,
+              borderColor: colorPalette[datasets.length % colorPalette.length],
+              backgroundColor: colorPalette[datasets.length % colorPalette.length] + '33',
+              tension: 0.1,
+              fill: false
+            });
+        }
+      });
+      
+      if (!hasAnyData) {
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        ctx.font = '16px Arial'; ctx.fillStyle = '#999'; ctx.textAlign = 'center';
+        ctx.fillText('No data available for current selection', canvas.width / 2, canvas.height / 2);
+        return;
+      }
+      
+      productionTrendsChart = new Chart(ctx, {
+        type: 'line',
+        data: { labels: graphProcesses, datasets: datasets },
+        options: {
+          responsive: true,
+          maintainAspectRatio: true,
+          plugins: {
+            title: {
+              display: true,
+              text: filterProduct ? `Production Time for ${filterProduct}` : 'Production Time by Process',
+              font: { size: 18, family: "'Playfair Display', serif" }
+            },
+            legend: { display: false },
+            tooltip: {
+              callbacks: {
+                label: function(context) {
+                  return[
+                    context.dataset.label,
+                    `Worker: ${context.raw.worker}`,
+                    `Time: ${formatDuration(context.raw.y)}`,
+                    `Cost: R ${context.raw.cost.toFixed(2)}`
+                  ];
+                }
+              }
+            }
+          },
+          scales: {
+            x: { title: { display: true, text: 'Production Process' } },
+            y: {
+              title: { display: true, text: 'Time (Hours)' },
+              beginAtZero: true,
+              ticks: { callback: function(value) { return formatDuration(value); } }
+            }
+          }
+        }
+      });
+    }
+
+    document.addEventListener('DOMContentLoaded', function() {
+      const productionTrendsTab = document.querySelector('button[data-bs-target="#tab-production-trends"]');
+      if (productionTrendsTab) {
+        productionTrendsTab.addEventListener('shown.bs.tab', function(event) {
+          if (!productionTrendsData) loadProductionTrends();
+        });
+      }
+    });
+
+    // --- WEEKLY COMPLETIONS LOGIC ---
+    let weeklyAnalyticsData = null;
+
+    // Load weekly completions when tab is shown for the first time
+    document.addEventListener('DOMContentLoaded', function() {
+      const weeklyCompletionsTab = document.querySelector('button[data-bs-target="#tab-weekly-completions"]');
+      if (weeklyCompletionsTab) {
+        weeklyCompletionsTab.addEventListener('shown.bs.tab', function(event) {
+          if (!weeklyAnalyticsData) {
+            loadWeeklyCompletions();
+          }
+        });
+      }
+    });
+
+    function loadWeeklyCompletions() {
+      const container = document.getElementById('weeklyCompletionsContainer');
+      container.innerHTML = '<div class="text-center p-5"><div class="spinner-border"></div></div>';
+      
+      google.script.run.withSuccessHandler(res => {
+        weeklyAnalyticsData = res;
+        
+        if (!res || !res.weeks || res.weeks.length === 0) {
+          container.innerHTML = '<div class="text-center p-5 text-muted">No completed processes found yet.</div>';
+          return;
+        }
+        
+        let html = '<div class="table-responsive"><table class="table table-bordered table-hover text-center align-middle mb-0"><thead class="table-dark"><tr>';
+        html += '<th class="text-start sticky-col">Week</th>';
+        
+        // Build Process Headers
+        res.processes.forEach(p => {
+          html += `<th>${p}</th>`;
+        });
+        html += '</tr></thead><tbody>';
+        
+        // Build Rows for each Week
+        res.weeks.forEach(week => {
+          html += `<tr><td class="text-start fw-bold bg-light sticky-col">${week}</td>`;
+          
+          res.processes.forEach(p => {
+            // Check if there is data for this week and process
+            const list = (res.data[week] && res.data[week][p]) ? res.data[week][p] :[];
+            
+            if (list.length > 0) {
+              // Create a clickable button if there are completed tasks
+              html += `<td><button class="btn btn-sm btn-outline-dark fw-bold w-100" onclick="showWeeklyDetails('${week}', '${p}')">${list.length}</button></td>`;
+            } else {
+              html += `<td class="text-muted">-</td>`;
+            }
+          });
+          html += '</tr>';
+        });
+        
+        html += '</tbody></table></div>';
+        container.innerHTML = html;
+        
+      }).getWeeklyAnalyticsData();
+    }
+
+    function showWeeklyDetails(week, process) {
+      if (!weeklyAnalyticsData) return;
+      
+      // Get the list of completed items for this specific cell
+      const list = (weeklyAnalyticsData.data[week] && weeklyAnalyticsData.data[week][process]) 
+                   ? weeklyAnalyticsData.data[week][process] 
+                   : []; // Completes the ternary operator
+
+      // Update the modal title to show what we are looking at
+      document.getElementById('weeklyDetailsTitle').innerText = `${week} - ${process}`;
+      
+      const tbody = document.getElementById('weeklyDetailsBody');
+      tbody.innerHTML = ''; // Clear previous data
+      
+      if (list.length === 0) {
+        tbody.innerHTML = '<tr><td colspan="3" class="text-center text-muted py-4">No details found.</td></tr>';
+      } else {
+        // Populate the rows with order data
+        list.forEach(item => {
+          tbody.innerHTML += `
+            <tr>
+              <td class="fw-bold">${item.orderNum}</td>
+              <td>${item.productName}</td>
+              <td><i class="bi bi-person-circle me-1"></i>${item.worker}</td>
+            </tr>
+          `;
+        });
+      }
+      
+      // Show the modal
+      if (weeklyDetailsModal) {
+        weeklyDetailsModal.show();
+      }
+    }
+
+    // STEP 6: Helper — builds the profile checkbox list strictly from the centralized appData.steelProfiles array.
+    function buildProfileCheckboxesHtml() {
+      // If no profiles exist in the Google Sheet, show a fallback message instead of hardcoded profiles
+      if (!appData.steelProfiles || appData.steelProfiles.length === 0) {
+        return '<div class="text-muted small py-1">No profiles found in Sheet.</div>';
+      }
+      
+      // Extract just the profile names for the checkboxes
+      const profiles = appData.steelProfiles.map(p => p.name);
+      
+      return profiles.map(p =>
+        `<div class="form-check mb-0"><input class="form-check-input profile-chk" type="checkbox" value="${p}"><label class="form-check-label mt-1">${p}</label></div>`
+      ).join('');
+    }
+
+    function openPowderModal() {
+      const tbody = document.getElementById('powderTableBody');
+      tbody.innerHTML = '';
+      
+      const readyOrders = appData.currentOrders.filter(o => o.status.toLowerCase() === 'ready for powder coating');
+      
+      if(readyOrders.length === 0) {
+          tbody.innerHTML = '<tr><td colspan="7" class="text-center text-muted py-4">No orders currently ready for powder coating.</td></tr>';
+      } else {
+          readyOrders.forEach((o, i) => {
+              const tr = document.createElement('tr');
+              tr.className = 'main-order-row';
+              tr.innerHTML = `
+                  <td class="text-center">
+                      <input class="form-check-input powder-select border-dark" type="checkbox" value="${o.order}" style="transform: scale(1.4); cursor: pointer; margin-top: 15px;">
+                  </td>
+                  <td class="text-center fw-bold" style="padding-top: 15px;">${o.order}</td>
+                  <td style="padding-top: 10px;">
+                      <div class="fw-bold main-desc mb-2">${o.productName || 'Unknown Product'}</div>
+                      <button type="button" class="btn btn-sm btn-outline-dark" style="font-size: 0.7rem; padding: 2px 6px;" onclick="addPowderSubPart(this, '${o.order}')">
+                          <i class="bi bi-plus"></i> Add Sub-Part
+                      </button>
+                  </td>
+                  <td style="padding-top: 10px;">
+                      <div class="d-flex align-items-center justify-content-center gap-1">
+                          <input type="text" inputmode="numeric" class="form-control form-control-sm text-center powder-h px-1" placeholder="H" style="width: 50px;"> x
+                          <input type="text" inputmode="numeric" class="form-control form-control-sm text-center powder-w px-1" placeholder="W" style="width: 50px;"> x
+                          <input type="text" inputmode="numeric" class="form-control form-control-sm text-center powder-d px-1" placeholder="D" style="width: 50px;">
+                      </div>
+                  </td>
+                  <td style="padding-top: 10px;">
+                      <input type="text" inputmode="numeric" class="form-control form-control-sm text-center powder-qty" value="1" style="width: 50px; margin: 0 auto;">
+                  </td>
+                  <td style="padding-top: 10px;">
+                      <input type="text" class="form-control form-control-sm powder-color" placeholder="e.g. Matte Black">
+                  </td>
+                  <td>
+                      <div class="border rounded p-1 text-start bg-white" style="max-height: 85px; overflow-y: auto; font-size: 0.75rem;">
+                          ${buildProfileCheckboxesHtml()}
+                      </div>
+                  </td>
+              `;
+              tbody.appendChild(tr);
+          });
+      }
+      
+      const powderModal = new bootstrap.Modal(document.getElementById('powderModal'));
+      powderModal.show();
+    }
+
+    // NEW FUNCTION: Injects a sub-part row underneath the parent order
+    function addPowderSubPart(btnElement, orderNum) {
+        const currentTr = btnElement.closest('tr');
+        
+        // Find the last row belonging to this order so we insert below existing sub-parts
+        let insertAfterTr = currentTr;
+        while (insertAfterTr.nextElementSibling && insertAfterTr.nextElementSibling.classList.contains('sub-part-row') && insertAfterTr.nextElementSibling.dataset.parentOrder === orderNum) {
+            insertAfterTr = insertAfterTr.nextElementSibling;
+        }
+        
+        const tr = document.createElement('tr');
+        tr.className = 'sub-part-row';
+        tr.style.backgroundColor = '#f8f9fa'; // Light grey to differentiate
+        tr.dataset.parentOrder = orderNum;
+        
+        tr.innerHTML = `
+            <td class="text-center border-end-0"></td>
+            <td class="text-center text-muted border-start-0 border-end-0" style="font-size: 1.2rem; padding-top:10px;">↳</td>
+            <td class="border-start-0" style="padding-top: 10px;">
+                <div class="d-flex gap-2 align-items-center">
+                    <input type="text" class="form-control form-control-sm sub-desc" placeholder="Part name (e.g. Door)">
+                    <button type="button" class="btn btn-sm btn-outline-danger" onclick="this.closest('tr').remove()" title="Remove Sub-part"><i class="bi bi-trash"></i></button>
+                </div>
+            </td>
+            <td style="padding-top: 10px;">
+                <div class="d-flex align-items-center justify-content-center gap-1">
+                    <input type="text" inputmode="numeric" class="form-control form-control-sm text-center powder-h px-1" placeholder="H" style="width: 50px;"> x
+                    <input type="text" inputmode="numeric" class="form-control form-control-sm text-center powder-w px-1" placeholder="W" style="width: 50px;"> x
+                    <input type="text" inputmode="numeric" class="form-control form-control-sm text-center powder-d px-1" placeholder="D" style="width: 50px;">
+                </div>
+            </td>
+            <td style="padding-top: 10px;">
+                <input type="text" inputmode="numeric" class="form-control form-control-sm text-center powder-qty" value="1" style="width: 50px; margin: 0 auto;">
+            </td>
+            <td style="padding-top: 10px;">
+                <input type="text" class="form-control form-control-sm powder-color" placeholder="Colour">
+            </td>
+            <td>
+                <div class="border rounded p-1 text-start bg-white" style="max-height: 85px; overflow-y: auto; font-size: 0.75rem;">
+                    ${buildProfileCheckboxesHtml()}
+                </div>
+            </td>
+        `;
+        insertAfterTr.insertAdjacentElement('afterend', tr);
+    }
+
+    // UPDATED FUNCTION: Grabs parent data AND sub-part data
+    function submitPowderList() {
+        const selected =[];
+        let isValid = true;
+        const submitBtn = document.querySelector('#powderModal .modal-footer .btn-primary');
+
+        document.querySelectorAll('.powder-select:checked').forEach(chk => {
+            const tr = chk.closest('tr');
+            const order = chk.value;
+            
+            // Get Main Order Info
+            const desc = tr.querySelector('.main-desc').innerText.trim();
+            const h = tr.querySelector('.powder-h').value.trim();
+            const w = tr.querySelector('.powder-w').value.trim();
+            const d = tr.querySelector('.powder-d').value.trim();
+            const qty = tr.querySelector('.powder-qty').value.trim();
+            const color = tr.querySelector('.powder-color').value.trim();
+            
+            const checkedProfiles = tr.querySelectorAll('.profile-chk:checked');
+            const profiles = Array.from(checkedProfiles).map(cb => cb.value).join(', ');
+            
+            if(!h || !w || !d || !qty || !color || profiles === "") isValid = false;
+
+            selected.push({
+                order: order, 
+                desc: desc, 
+                dimensions: h + 'x' + w + 'x' + d, 
+                qty: qty, 
+                color: color, 
+                profiles: profiles
+            });
+
+            // Get Sub-Parts linked to this order
+            const subRows = document.querySelectorAll(`.sub-part-row[data-parent-order="${order}"]`);
+            subRows.forEach(subTr => {
+                const subDescInput = subTr.querySelector('.sub-desc').value.trim();
+                const subH = subTr.querySelector('.powder-h').value.trim();
+                const subW = subTr.querySelector('.powder-w').value.trim();
+                const subD = subTr.querySelector('.powder-d').value.trim();
+                const subQty = subTr.querySelector('.powder-qty').value.trim();
+                const subColor = subTr.querySelector('.powder-color').value.trim();
+                
+                const subCheckedProfiles = subTr.querySelectorAll('.profile-chk:checked');
+                const subProfiles = Array.from(subCheckedProfiles).map(cb => cb.value).join(', ');
+
+                if(!subDescInput || !subH || !subW || !subD || !subQty || !subColor || subProfiles === "") {
+                    isValid = false;
+                }
+
+                selected.push({
+                    order: "", // Left blank so it indents visually under the parent order in the PDF
+                    desc: "↳ " + subDescInput, 
+                    dimensions: subH + 'x' + subW + 'x' + subD, 
+                    qty: subQty, 
+                    color: subColor, 
+                    profiles: subProfiles
+                });
+            });
+        });
+        
+        if(selected.length === 0) {
+            showAlert("Please select at least one order to send.");
+            return;
+        }
+        
+        if(!isValid) {
+            showAlert("Please fill in ALL inputs (Name, Dimensions, QTY, Colour, Profile) for all checked orders AND their sub-parts.");
+            return;
+        }
+        
+        // Show Loading State
+        isSubmitting = true;
+        const originalBtnText = submitBtn.innerHTML;
+        submitBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>GENERATING PDF...';
+        submitBtn.disabled = true;
+
+        // Send to backend
+        google.script.run
+            .withSuccessHandler((res) => {
+                isSubmitting = false;
+                submitBtn.innerHTML = originalBtnText;
+                submitBtn.disabled = false;
+                
+                if(res.success) {
+                    showAlert("List generated successfully and saved to your Drive!");
+                    const powderModalEl = document.getElementById('powderModal');
+                    const powderModalInstance = bootstrap.Modal.getInstance(powderModalEl);
+                    if (powderModalInstance) powderModalInstance.hide();
+                } else {
+                    showAlert("Error generating PDF: " + res.error);
+                }
+            })
+            .withFailureHandler((err) => {
+                isSubmitting = false;
+                submitBtn.innerHTML = originalBtnText;
+                submitBtn.disabled = false;
+                showAlert("System Error: " + err);
+            })
+            .generatePowderCoatingList(selected, session.name);
+    }
+
+    function initSigPad() {
+      canvas = document.getElementById('sigCanvas'); 
+      ctx = canvas.getContext('2d');
+      
+      // Set initial drawing properties (will be properly set in initCanvas)
+      ctx.lineWidth = 2;
+      ctx.lineCap = 'round';
+      ctx.lineJoin = 'round';
+      ctx.strokeStyle = '#000';
+      
+      // Check if browser supports pointer events
+      if (window.PointerEvent) {
+        // Pointer events - unified API for all input types (mouse, touch, stylus)
+        canvas.addEventListener('pointerdown', handlePointerDown);
+        canvas.addEventListener('pointermove', handlePointerMove);
+        canvas.addEventListener('pointerup', handlePointerEnd);
+        canvas.addEventListener('pointercancel', handlePointerEnd);
+        canvas.addEventListener('pointerleave', handlePointerEnd);
+      } else {
+        // Fallback to traditional mouse/touch events for older browsers
+        // Mouse events
+        canvas.addEventListener('mousedown', sD); 
+        canvas.addEventListener('mousemove', dD); 
+        canvas.addEventListener('mouseup', () => isDrawing=false);
+        canvas.addEventListener('mouseleave', () => isDrawing=false);
+        
+        // Touch events - handle differently to ensure proper coordinates
+        canvas.addEventListener('touchstart', handleTouchStart, {passive: false}); 
+        canvas.addEventListener('touchmove', handleTouchMove, {passive: false});
+        canvas.addEventListener('touchend', handleTouchEnd, {passive: false});
+        canvas.addEventListener('touchcancel', handleTouchEnd, {passive: false});
+      }
+
+      // --- STEP 3.2: RESPONSIVE CANVAS RESIZE HANDLER ---
+      // When the device is rotated, save the current signature, resize the canvas
+      // to match its new container width, then redraw the saved signature.
+      let _resizeTimer = null;
+      window.addEventListener('resize', () => {
+        // Only act when the QC modal is actually open and the canvas is visible
+        if (!canvas || canvas.offsetParent === null) return;
+
+        // Save the current drawing as a data URL before the canvas is resized
+        const savedSignature = hasSigned ? canvas.toDataURL() : null;
+
+        // Re-initialize the canvas dimensions to the new container size
+        initCanvas();
+
+        // Restore the saved signature if there was one
+        if (savedSignature && hasSigned) {
+          const img = new Image();
+          img.onload = () => {
+            if (ctx) {
+              ctx.drawImage(img, 0, 0, canvas.getBoundingClientRect().width, canvas.getBoundingClientRect().height);
+            }
+          };
+          img.src = savedSignature;
+        }
+      });
+    }
+    
+    // Initialize/reset canvas dimensions
+    function initCanvas() {
+      if (!canvas || !ctx) {
+        console.debug('Canvas not ready for initialization');
+        return;
+      }
+      
+      const rect = canvas.getBoundingClientRect();
+      
+      // Skip if canvas doesn't have dimensions yet (modal not fully shown)
+      if (rect.width === 0 || rect.height === 0) {
+        console.warn('Canvas dimensions not available yet (width: ' + rect.width + ', height: ' + rect.height + '). Canvas initialization skipped.');
+        return;
+      }
+      
+      // Handle high DPI displays (Retina, etc.)
+      const dpr = window.devicePixelRatio || 1;
+      
+      // Save current drawing if canvas already has valid dimensions
+      let imgData = null;
+      if (canvas.width > 0 && canvas.height > 0) {
+        try {
+          imgData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+        } catch(e) {
+          console.debug('Canvas not ready for saving image data:', e.message);
+        }
+      }
+      
+      // Set canvas resolution to match its display size, accounting for device pixel ratio
+      canvas.width = rect.width * dpr;
+      canvas.height = rect.height * dpr;
+      
+      // Reset transform and scale the context to account for device pixel ratio
+      ctx.setTransform(1, 0, 0, 1, 0, 0); // Reset to identity matrix
+      ctx.scale(dpr, dpr);
+      
+      // Restore drawing if it existed
+      if (imgData) {
+        try {
+          ctx.putImageData(imgData, 0, 0);
+        } catch(e) {
+          console.debug('Failed to restore canvas image:', e.message);
+        }
+      }
+      
+      // Set/restore drawing properties (in case context was reset)
+      // Note: After ctx.scale(dpr, dpr), coordinates are automatically scaled
+      // but lineWidth of 2 remains appropriate as it's also scaled by the transformation
+      ctx.lineWidth = 2;
+      ctx.lineCap = 'round';
+      ctx.lineJoin = 'round';
+      ctx.strokeStyle = '#000';
+    }
+    
+    // Unified pointer event handlers (works for mouse, touch, stylus, pen)
+    function handlePointerDown(e) {
+      e.preventDefault();
+      const rect = canvas.getBoundingClientRect();
+      isDrawing = true;
+      hasSigned = true;
+      ctx.beginPath();
+      ctx.moveTo(e.clientX - rect.left, e.clientY - rect.top);
+    }
+    
+    function handlePointerMove(e) {
+      e.preventDefault();
+      if (!isDrawing) return;
+      const rect = canvas.getBoundingClientRect();
+      ctx.lineTo(e.clientX - rect.left, e.clientY - rect.top);
+      ctx.stroke();
+    }
+    
+    function handlePointerEnd(e) {
+      e.preventDefault();
+      isDrawing = false;
+    }
+    
+    function handleTouchStart(e) {
+      e.preventDefault();
+      // Only handle single touch (ignore multi-touch)
+      if (e.touches.length > 1) return;
+      const touch = e.touches[0];
+      const rect = canvas.getBoundingClientRect();
+      isDrawing = true;
+      hasSigned = true;
+      ctx.beginPath();
+      ctx.moveTo(touch.clientX - rect.left, touch.clientY - rect.top);
+    }
+    
+    function handleTouchMove(e) {
+      e.preventDefault();
+      if (!isDrawing) return;
+      // Only handle single touch (ignore multi-touch)
+      if (e.touches.length > 1) {
+        isDrawing = false;
+        return;
+      }
+      const touch = e.touches[0];
+      const rect = canvas.getBoundingClientRect();
+      ctx.lineTo(touch.clientX - rect.left, touch.clientY - rect.top);
+      ctx.stroke();
+    }
+    
+    function handleTouchEnd(e) {
+      e.preventDefault();
+      isDrawing = false;
+    }
+    
+    function sD(e) { 
+      isDrawing=true; 
+      hasSigned=true; 
+      const r=canvas.getBoundingClientRect(); 
+      ctx.beginPath(); 
+      ctx.moveTo(e.clientX-r.left, e.clientY-r.top); 
+    }
+    
+    function dD(e) { 
+      if(!isDrawing)return; 
+      const r=canvas.getBoundingClientRect(); 
+      ctx.lineTo(e.clientX-r.left, e.clientY-r.top); 
+      ctx.stroke(); 
+    }
+    
+    function clearSignature() { 
+      hasSigned=false; 
+      if (canvas && canvas.width > 0 && canvas.height > 0) {
+        ctx.clearRect(0, 0, canvas.width, canvas.height); 
+      }
+    }
+
+    // --- ADMIN QC REPORTS LOGIC ---
+    let qcReportsData = [];
+
+
+    function showSwitchBanner(notice) {
+      const el = document.getElementById('switchBanner');
+      if (!el) return;
+      document.getElementById('switchBannerTitle').innerText = 'Plate ready';
+      document.getElementById('switchBannerMsg').innerText = notice.message || ('You are back on order ' + notice.resumedOrder);
+      el.classList.add('show');
+    }
+    function dismissSwitchBanner() {
+      const el = document.getElementById('switchBanner');
+      if (el) el.classList.remove('show');
+    }
+    function undoSwitch() {
+      google.script.run.withSuccessHandler(res => {
+        dismissSwitchBanner();
+        if (!res.success) showAlert(res.message || 'Could not undo');
+        loadDashboard(true);
+      }).undoAutoSwitch(session.name);
+    }
+    function leaveBatchNow(orderNum) {
+      google.script.run.withSuccessHandler(res => {
+        if (!res.success) showAlert(res.message || 'Could not leave batch');
+        loadDashboard(true);
+      }).leaveBatchForOrder(session.name, orderNum);
+    }
+
+    function loadIdleWorkers() {
+      const box = document.getElementById('idleWorkersList');
+      if (!box) return;
+      google.script.run.withSuccessHandler(data => {
+        const workers = (data && data.workers) || [];
+        const tasks = (data && data.tasks) || [];
+        if (!workers.length) {
+          box.innerHTML = '<span class="text-muted small">No idle workers right now.</span>';
+          return;
+        }
+        box.innerHTML = workers.map(w => {
+          const opts = tasks.map(task => '<option value="'+task+'">'+task+'</option>').join('');
+          const since = w.idleSince ? new Date(w.idleSince).toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'}) : 'unknown';
+          return `<div class="d-flex flex-wrap gap-2 align-items-center mb-2">
+            <strong>${w.worker}</strong>
+            <span class="badge bg-light text-dark border">${w.role}</span>
+            <span class="small text-muted">idle since ${since}</span>
+            <select class="form-select form-select-sm" style="max-width:220px" id="idle-task-${w.row}">${opts}</select>
+            <button class="btn btn-sm btn-dark" onclick="assignIdleTask('${w.worker}', ${w.row})">ASSIGN TASK</button>
+          </div>`;
+        }).join('');
+      }).withFailureHandler(err => {
+        box.innerHTML = '<span class="text-danger small">'+err+'</span>';
+      }).getIdleWorkers();
+    }
+
+    function assignIdleTask(worker, row) {
+      const sel = document.getElementById('idle-task-' + row);
+      const task = sel ? sel.value : 'Other';
+      google.script.run.withSuccessHandler(res => {
+        if (!res.success) showAlert(res.message || 'Assign failed');
+        loadIdleWorkers();
+      }).assignIndirectTask(worker, task, session.name);
+    }
+
+    function loadActivityReport() {
+      navTo('view-admin-activity');
+      const periodEl = document.getElementById('activityPeriod');
+      const dateEl = document.getElementById('activityDate');
+      const workerEl = document.getElementById('activityWorker');
+      if (dateEl && !dateEl.value) {
+        const d = new Date();
+        dateEl.value = d.toISOString().slice(0,10);
+      }
+      const period = periodEl ? periodEl.value : 'day';
+      const refMs = dateEl && dateEl.value ? new Date(dateEl.value + 'T12:00:00').getTime() : Date.now();
+      const worker = workerEl ? workerEl.value : '';
+      document.getElementById('activityTable').innerHTML = '<div class="text-center p-4"><div class="spinner-border"></div></div>';
+      google.script.run.withSuccessHandler(data => {
+        renderActivityReport(data);
+      }).withFailureHandler(err => {
+        document.getElementById('activityTable').innerHTML = '<div class="text-danger p-3">'+err+'</div>';
+      }).getActivityReport(period, refMs, worker);
+    }
+
+    function renderActivityReport(data) {
+      const workerEl = document.getElementById('activityWorker');
+      if (workerEl) {
+        const current = workerEl.value;
+        const names = {};
+        (data.allWorkerNames || []).forEach(n => { names[n] = true; });
+        (data.workers || []).forEach(w => { names[w.worker] = true; });
+        let html = '<option value="">All workers</option>';
+        Object.keys(names).sort().forEach(n => {
+          html += '<option value="' + n + '"' + (n === current ? ' selected' : '') + '>' + n + '</option>';
+        });
+        workerEl.innerHTML = html;
+      }
+      let regular = 0, ot = 0, overDays = 0;
+      (data.workers || []).forEach(w => {
+        regular += w.totalRegular || 0;
+        ot += w.totalOvertime || 0;
+        (w.days || []).forEach(d => { if (d.overLimit) overDays++; });
+      });
+      document.getElementById('activityRegular').innerText = formatDuration(regular);
+      document.getElementById('activityOt').innerText = formatDuration(ot);
+      document.getElementById('activityOverDays').innerText = overDays;
+
+      const labels = [];
+      const regularData = [];
+      const otData = [];
+      (data.workers || []).forEach(w => {
+        labels.push(w.worker);
+        regularData.push(Math.round((w.totalRegular || 0)/60 * 10)/10);
+        otData.push(Math.round((w.totalOvertime || 0)/60 * 10)/10);
+      });
+      const canvas = document.getElementById('activityChart');
+      if (canvas && window.Chart) {
+        if (activityChart) activityChart.destroy();
+        activityChart = new Chart(canvas, {
+          type: 'bar',
+          data: {
+            labels: labels,
+            datasets: [
+              { label: 'Regular hours', data: regularData, backgroundColor: '#0f172a' },
+              { label: 'Overtime hours', data: otData, backgroundColor: '#f59e0b' }
+            ]
+          },
+          options: {
+            responsive: true,
+            plugins: { legend: { position: 'bottom' } },
+            scales: { x: { stacked: true }, y: { stacked: true, title: { display: true, text: 'Hours' } } }
+          }
+        });
+      }
+
+      let html = '';
+      (data.workers || []).forEach(w => {
+        html += `<div class="p-3 border-bottom"><h5 class="mb-2">${w.worker} <span class="badge bg-dark">${formatDuration(w.totalMinutes)}</span> <span class="badge ot-badge">OT ${formatDuration(w.totalOvertime)}</span></h5>`;
+        html += `<div class="table-responsive"><table class="table table-sm mb-2"><thead><tr><th>Date</th><th>Regular</th><th>Overtime</th><th>Total</th></tr></thead><tbody>`;
+        (w.days || []).forEach(d => {
+          const cls = d.overLimit ? 'over-limit-row' : '';
+          html += `<tr class="${cls}"><td>${d.date}</td><td>${formatDuration(d.regular)}</td><td>${formatDuration(d.overtime)}</td><td>${formatDuration(d.minutes)}</td></tr>`;
+        });
+        html += `</tbody></table></div>`;
+        html += `<div class="small text-muted mb-1">What they did</div><ul class="mb-0">`;
+        (w.tasks || []).slice(0, 40).forEach(task => {
+          const kind = task.entryType === 'indirect' ? 'Non-order' : (task.order || '');
+          html += `<li><strong>${task.task}</strong> · ${kind} · ${formatDuration(task.minutes)}${task.end ? '' : ' (running)'}</li>`;
+        });
+        html += `</ul></div>`;
+      });
+      if (!html) html = '<div class="text-muted p-4">No activity in this period.</div>';
+      document.getElementById('activityTable').innerHTML = html;
+    }
+
+    function loadQCReports() {
+      navTo('view-admin-qc-reports');
+      document.getElementById('qcReportsContainer').innerHTML = '<div class="text-center p-5"><div class="spinner-border"></div></div>';
+      
+      google.script.run
+        .withSuccessHandler(res => {
+          qcReportsData = res;
+          renderQCReports();
+        })
+        .withFailureHandler(err => {
+          document.getElementById('qcReportsContainer').innerHTML = `<div class="text-danger p-4 text-center">Error loading reports: ${err}</div>`;
+        })
+        .getQCReportsFast();
+    }
+
+    function renderQCReports() {
+      const q = document.getElementById('qcReportSearch').value.toLowerCase();
+      let html = '<div class="list-group list-group-flush">';
+      let count = 0;
+      
+      qcReportsData.forEach(file => {
+        if (q && !file.name.toLowerCase().includes(q)) return;
+        count++;
+        const d = new Date(file.dateCreated).toLocaleString();
+        
+        html += `
+          <a href="${file.url}" target="_blank" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center py-3">
+            <div>
+              <strong class="d-block text-dark">${file.name}</strong>
+              <small class="text-muted"><i class="bi bi-clock me-1"></i>${d}</small>
+            </div>
+            <i class="bi bi-file-earmark-pdf-fill fs-4 text-danger"></i>
+          </a>
+        `;
+      });
+      
+      if (count === 0) {
+        html += '<div class="text-center text-muted p-5">No QC Reports found.</div>';
+      }
+      html += '</div>';
+      
+      document.getElementById('qcReportsContainer').innerHTML = html;
+    }
+  </script>
+</body>
+</html>

--- a/studio-delta-production/index.html
+++ b/studio-delta-production/index.html
@@ -1199,6 +1199,21 @@
       </div>
     </div>
   </div>
+  <div class="modal fade" id="runningChoiceModal" tabindex="-1">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content p-4 text-center">
+        <h3 class="brand-font mb-2">Already working</h3>
+        <p class="mb-3" id="runningChoiceMsg">You already have an order running.</p>
+        <div id="runningChoiceList" class="text-start mb-3 small"></div>
+        <p class="small text-muted mb-3">Together = one clock, time split across the orders. Switch = pause the current order (you will need a reason) and start the new one.</p>
+        <div class="d-grid gap-2">
+          <button class="btn btn-dark" id="btnWorkTogether" onclick="confirmWorkTogether()">Work on A and B</button>
+          <button class="btn btn-outline-dark" id="btnSwitchOrders" onclick="confirmSwitchFromRunning()">Switch from A to B</button>
+          <button class="btn btn-link text-muted" data-bs-dismiss="modal">Cancel</button>
+        </div>
+      </div>
+    </div>
+  </div>
   <div class="modal fade" id="qcModal" tabindex="-1"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><h5 class="modal-title brand-font">Checklist</h5><button class="btn-close" data-bs-dismiss="modal"></button></div><div class="modal-body p-4">
     <div class="mb-3"><strong>Order:</strong> <span id="qcOrderNum"></span></div>
     <div id="qcChecklistContainer"></div>
@@ -1465,13 +1480,14 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <script>
     let appData = { users:[], workerStats: {}, currentOrders:[], steelProfiles:[], backboards:[] };
-    let session = { role: null, name: null, pendingRow: null, activeOrder: null, logId: null, logIds: {}, isAdmin: false, isQcOnly: false, tasks: [], jobTitle: '', pendingBatchRows: null, pendingBatchMates: [], pendingStartTask: null, pendingSwitchReason: null, pauseModalMode: 'pause' };
+    let session = { role: null, name: null, pendingRow: null, activeOrder: null, logId: null, logIds: {}, isAdmin: false, isQcOnly: false, tasks: [], jobTitle: '', pendingBatchRows: null, pendingBatchMates: [], pendingStartTask: null, pendingSwitchReason: null, pendingWorkTogether: false, pendingStartMode: null, skipRunningChoice: false, startConfirmed: false, pendingRunningOrders: [], pauseModalMode: 'pause' };
     let idleAlertModal = null;
     let backboardSelectionModal = null;
     let idlePollTimer = null;
     let idleAlertDismissedKey = '';
     let activityChart = null;
     let batchWorkModal = null;
+    let runningChoiceModal = null;
     let refreshInterval = null;
     let liveTimerInterval = null;
     let hasSigned = false;
@@ -1613,6 +1629,7 @@
         idleAlertModal = new bootstrap.Modal('#idleAlertModal');
         welderSteelModal = new bootstrap.Modal('#welderSteelModal');
         batchWorkModal = new bootstrap.Modal('#batchWorkModal');
+        runningChoiceModal = new bootstrap.Modal('#runningChoiceModal');
         
         document.getElementById('confirmBtnYes').onclick = () => { if (confirmModal) confirmModal.hide(); if(confirmCallback) confirmCallback(); };
         
@@ -1908,7 +1925,7 @@
     }
     
     function logout() { 
-      session = { role: null, name: null, pendingRow: null, activeOrder: null, logId: null, logIds: {}, isAdmin: false, isQcOnly: false, tasks: [], jobTitle: '', pendingBatchRows: null, pendingBatchMates: [], pendingStartTask: null, pendingSwitchReason: null, pauseModalMode: 'pause' }; 
+      session = { role: null, name: null, pendingRow: null, activeOrder: null, logId: null, logIds: {}, isAdmin: false, isQcOnly: false, tasks: [], jobTitle: '', pendingBatchRows: null, pendingBatchMates: [], pendingStartTask: null, pendingSwitchReason: null, pendingWorkTogether: false, pendingStartMode: null, skipRunningChoice: false, startConfirmed: false, pendingRunningOrders: [], pauseModalMode: 'pause' }; 
       clearPersistedSession();
       stopIdleAlertPolling();
       idleAlertDismissedKey = '';
@@ -1988,7 +2005,20 @@
     function batchStart() {
         const selected = Array.from(document.querySelectorAll('.batch-select:checked')).map(el => parseInt(el.value));
         if(selected.length === 0) return;
-        
+        const running = myRunningOrders(selected);
+        if (running.length && !session.pendingWorkTogether && !session.pendingSwitchReason && !session.skipRunningChoice) {
+          session.pendingStartMode = 'batch-start';
+          session.pendingRow = selected[0];
+          session.pendingBatchRows = selected;
+          const newNames = selected.map(rowIndex => {
+            const o = (appData.currentOrders || []).find(ord => ord.rowIndex === rowIndex);
+            return o ? o.order : ('#' + rowIndex);
+          });
+          showRunningChoiceModal(running, newNames);
+          return;
+        }
+        session.skipRunningChoice = false;
+
         isSubmitting = true;
         const btn = document.getElementById('btnBatchStart');
         const origText = btn.innerHTML;
@@ -2007,6 +2037,14 @@
                 if (res && res.needsSwitchReason) {
                   session.pendingRow = selected[0];
                   session.pendingBatchRows = selected;
+                  if (!session.skipRunningChoice && !session.pendingWorkTogether) {
+                    session.pendingStartMode = 'batch-start';
+                    showRunningChoiceModal(res.runningOrders, session.activeOrder || selected.map(rowIndex => {
+                      const o = (appData.currentOrders || []).find(ord => ord.rowIndex === rowIndex);
+                      return o ? o.order : '';
+                    }));
+                    return;
+                  }
                   openLeaveReasonModal('switch-start', res.runningOrders);
                   return;
                 }
@@ -2014,6 +2052,8 @@
                   showAlert(res.message || res.error || "Could not start");
                 }
                 session.pendingSwitchReason = null;
+                session.pendingWorkTogether = false;
+                session.skipRunningChoice = false;
                 loadDashboard(true);
             })
             .withFailureHandler(err => {
@@ -2023,7 +2063,7 @@
                 showAlert("Error: " + err);
                 loadDashboard(true);
             })
-            .batchStartOrders(selected, session.name, session.role, session.pendingSwitchReason);
+            .batchStartOrders(selected, session.name, session.role, session.pendingSwitchReason, !!session.pendingWorkTogether);
     }
     
     function batchFinish() {
@@ -2186,7 +2226,7 @@
           } else {
              if (isMine) {
                if (o.isPaused) {
-                 innerBtn = `<button class="btn btn-success w-100 position-relative" style="z-index: 10;" onclick="event.stopPropagation(); event.preventDefault(); confirmResume(${o.rowIndex}, '${o.order}')">RESUME</button>`;
+                 innerBtn = `<button class="btn btn-success w-100 position-relative" style="z-index: 10;" onclick="event.stopPropagation(); event.preventDefault(); preResume(${o.rowIndex}, '${o.order}')">RESUME</button>`;
                } else {
                  innerBtn = `
                    <div class="d-flex gap-2 position-relative w-100 flex-wrap" style="z-index: 10;">
@@ -2337,13 +2377,79 @@
       }
     }
 
-    function preStart(row, ord, startTask) { 
-      session.pendingRow = row; 
-      session.activeOrder = ord;
-      session.pendingStartTask = startTask || startTaskForOrder((appData.currentOrders || []).find(o => o.rowIndex === row)) || session.role;
-      session.pendingBatchRows = null;
-      session.pendingBatchMates = [];
+    function formatOrderNames(names) {
+      const list = (names || []).filter(Boolean).map(n => String(n));
+      if (!list.length) return '';
+      if (list.length === 1) return list[0];
+      if (list.length === 2) return list[0] + ' and ' + list[1];
+      return list.slice(0, -1).join(', ') + ' and ' + list[list.length - 1];
+    }
 
+    function myRunningOrders(exceptRows) {
+      const except = new Set((exceptRows || []).map(n => parseInt(n, 10)));
+      return (appData.currentOrders || []).filter(o =>
+        o.assigned === session.name &&
+        !o.isPaused &&
+        !except.has(o.rowIndex)
+      );
+    }
+
+    function showRunningChoiceModal(running, newOrderNames) {
+      session.pendingRunningOrders = running || [];
+      const runningNames = (running || []).map(o => o.order).filter(Boolean);
+      const newNames = Array.isArray(newOrderNames) ? newOrderNames : [newOrderNames];
+      const fromLabel = formatOrderNames(runningNames) || 'the current order';
+      const toLabel = formatOrderNames(newNames) || 'the new order';
+      const togetherLabel = formatOrderNames(runningNames.concat(newNames));
+      document.getElementById('runningChoiceMsg').innerText =
+        'You have ' + fromLabel + ' running. Work together, or switch to ' + toLabel + '?';
+      document.getElementById('runningChoiceList').innerHTML =
+        '<div><strong>Running:</strong> ' + fromLabel + '</div><div><strong>New:</strong> ' + toLabel + '</div>';
+      document.getElementById('btnWorkTogether').innerText = 'Work on ' + togetherLabel;
+      document.getElementById('btnSwitchOrders').innerText = 'Switch from ' + fromLabel + ' to ' + toLabel;
+      if (runningChoiceModal) runningChoiceModal.show();
+    }
+
+    function confirmWorkTogether() {
+      session.pendingWorkTogether = true;
+      session.skipRunningChoice = true;
+      if (runningChoiceModal) runningChoiceModal.hide();
+      if (session.pendingStartMode === 'resume') {
+        confirmResume(session.pendingRow, session.activeOrder);
+        return;
+      }
+      if (session.pendingStartMode === 'batch-start') {
+        batchStart();
+        return;
+      }
+      if (session.startConfirmed) {
+        confirmStart();
+        return;
+      }
+      continueToStartModal();
+    }
+
+    function confirmSwitchFromRunning() {
+      session.pendingWorkTogether = false;
+      session.skipRunningChoice = true;
+      if (runningChoiceModal) runningChoiceModal.hide();
+      if (session.pendingStartMode === 'resume') {
+        confirmResume(session.pendingRow, session.activeOrder);
+        return;
+      }
+      if (session.pendingStartMode === 'batch-start') {
+        batchStart();
+        return;
+      }
+      if (session.startConfirmed) {
+        openLeaveReasonModal('switch-start', session.pendingRunningOrders);
+        return;
+      }
+      offerSameProductOrStart();
+    }
+
+    function offerSameProductOrStart() {
+      const row = session.pendingRow;
       const current = (appData.currentOrders || []).find(o => o.rowIndex === row);
       if ((session.pendingStartTask || session.role) === 'Assembly' && current && current.productName) {
         const mates = (appData.currentOrders || []).filter(o =>
@@ -2356,7 +2462,7 @@
         if (mates.length) {
           session.pendingBatchMates = mates;
           document.getElementById('batchWorkMsg').innerText =
-            current.productName + ' on ' + ord + ' matches ' + mates.length + ' other order(s). Cut slats together?';
+            current.productName + ' on ' + session.activeOrder + ' matches ' + mates.length + ' other order(s). Cut slats together?';
           document.getElementById('batchWorkList').innerHTML = mates.map(m =>
             '<div><strong>' + m.order + '</strong> · ' + (m.productName || '') + '</div>'
           ).join('');
@@ -2365,6 +2471,26 @@
         }
       }
       continueToStartModal();
+    }
+
+    function preStart(row, ord, startTask) { 
+      session.pendingRow = row; 
+      session.activeOrder = ord;
+      session.pendingStartTask = startTask || startTaskForOrder((appData.currentOrders || []).find(o => o.rowIndex === row)) || session.role;
+      session.pendingBatchRows = null;
+      session.pendingBatchMates = [];
+      session.pendingWorkTogether = false;
+      session.pendingSwitchReason = null;
+      session.skipRunningChoice = false;
+      session.pendingStartMode = 'start';
+      session.startConfirmed = false;
+
+      const running = myRunningOrders([row]);
+      if (running.length) {
+        showRunningChoiceModal(running, ord);
+        return;
+      }
+      offerSameProductOrStart();
     }
 
     function confirmBatchTogether() {
@@ -2383,6 +2509,7 @@
     function confirmStart() {
       if (isSubmitting) return; 
       isSubmitting = true;
+      session.startConfirmed = true;
       if (startModal) startModal.hide();
       
       // NEW: Reset the Phase Filter to "All" so the user can see their newly started order
@@ -2411,15 +2538,21 @@
            }
            session.pendingBatchRows = null;
            session.pendingSwitchReason = null;
+           session.pendingWorkTogether = false;
+           session.skipRunningChoice = false;
            loadDashboard(true);
         } else if (res.needsSwitchReason) {
            loadDashboard(true);
-           openLeaveReasonModal('switch-start', res.runningOrders);
-        } else {
+           if (!session.skipRunningChoice && !session.pendingWorkTogether) {
+             session.pendingStartMode = 'start';
+             showRunningChoiceModal(res.runningOrders, session.activeOrder);
+           } else {
+             openLeaveReasonModal('switch-start', res.runningOrders);
+           } else {
            showAlert(res.message || res.error || "Could not start");
            loadDashboard();
         }
-      }).withFailureHandler(err => { isSubmitting=false; showAlert("Error: "+err); loadDashboard(); }).startOrder(session.pendingRow, session.name, session.pendingStartTask || session.role, session.pendingBatchRows, session.pendingSwitchReason);
+      }).withFailureHandler(err => { isSubmitting=false; showAlert("Error: "+err); loadDashboard(); }).startOrder(session.pendingRow, session.name, session.pendingStartTask || session.role, session.pendingBatchRows, session.pendingSwitchReason, !!session.pendingWorkTogether);
     }
 
     function onPauseReasonChange() {
@@ -2520,6 +2653,21 @@
       }).withFailureHandler(err => { isSubmitting=false; showAlert("Error: "+err); loadDashboard(); }).workerPauseOrder(session.pendingRow, session.activeOrder, session.name, reason);
     }
 
+    function preResume(row, ord) {
+      session.pendingRow = row;
+      session.activeOrder = ord;
+      session.pendingStartMode = 'resume';
+      session.pendingWorkTogether = false;
+      session.pendingSwitchReason = null;
+      session.skipRunningChoice = false;
+      const running = myRunningOrders([row]);
+      if (running.length) {
+        showRunningChoiceModal(running, ord);
+        return;
+      }
+      confirmResume(row, ord);
+    }
+
     function confirmResume(row, ord) {
       if (isSubmitting) return;
       isSubmitting = true;
@@ -2537,15 +2685,21 @@
         isSubmitting = false;
         if(res.success) {
            session.pendingSwitchReason = null;
+           session.pendingWorkTogether = false;
+           session.skipRunningChoice = false;
            loadDashboard(true);
         } else if (res.needsSwitchReason) {
            loadDashboard(true);
-           openLeaveReasonModal('switch-resume', res.runningOrders);
-        } else {
+           if (!session.skipRunningChoice && !session.pendingWorkTogether) {
+             session.pendingStartMode = 'resume';
+             showRunningChoiceModal(res.runningOrders, session.activeOrder);
+           } else {
+             openLeaveReasonModal('switch-resume', res.runningOrders);
+           } else {
            showAlert(res.message);
            loadDashboard();
         }
-      }).withFailureHandler(err => { isSubmitting=false; showAlert("Error: "+err); loadDashboard(); }).workerResumeOrder(session.pendingRow, session.activeOrder, session.name, session.pendingSwitchReason);
+      }).withFailureHandler(err => { isSubmitting=false; showAlert("Error: "+err); loadDashboard(); }).workerResumeOrder(session.pendingRow, session.activeOrder, session.name, session.pendingSwitchReason, !!session.pendingWorkTogether);
     }
 
 

--- a/studio-delta-production/index.html
+++ b/studio-delta-production/index.html
@@ -1744,39 +1744,50 @@
       enterDashboard();
     }
 
-    function initApp() {
-      // Fire both backend calls in parallel; hide loader after both return.
-      let usersLoaded = false;
-      let profilesLoaded = false;
-      function checkAllLoaded() {
-        if (usersLoaded && profilesLoaded) {
-          document.getElementById('loader').classList.add('d-none');
-          if (restoreSession()) {
-            setLoggedIn(true);
-            if (session.isAdmin) document.getElementById('adminLinks').classList.remove('d-none-view');
-            updateFloorLink();
-            if (session.isAdmin && !session.role) {
-              loadProductionOverview();
-              loadIdleWorkers();
-            } else if (session.role) {
-              enterDashboard();
-            } else {
-              routeAfterLogin();
-            }
-          }
-        }
-      }
+    function prefetchSupportData() {
       google.script.run.withSuccessHandler(data => {
-        appData.users = data;
-        usersLoaded = true;
-        checkAllLoaded();
-      }).withFailureHandler(() => { usersLoaded = true; checkAllLoaded(); }).getUsersAndRoles();
-
+        appData.users = data || [];
+      }).getUsersAndRoles();
       google.script.run.withSuccessHandler(profiles => {
         appData.steelProfiles = profiles || [];
-        profilesLoaded = true;
-        checkAllLoaded();
-      }).withFailureHandler(() => { profilesLoaded = true; checkAllLoaded(); }).getSteelProfiles();
+      }).getSteelProfiles();
+    }
+    function ensureSteelProfiles(cb) {
+      if (appData.steelProfiles && appData.steelProfiles.length) {
+        if (cb) cb();
+        return;
+      }
+      google.script.run.withSuccessHandler(profiles => {
+        appData.steelProfiles = profiles || [];
+        if (cb) cb();
+      }).withFailureHandler(() => { if (cb) cb(); }).getSteelProfiles();
+    }
+    function ensureUsers(cb) {
+      if (appData.users && appData.users.length) {
+        if (cb) cb();
+        return;
+      }
+      google.script.run.withSuccessHandler(data => {
+        appData.users = data || [];
+        if (cb) cb();
+      }).withFailureHandler(() => { if (cb) cb(); }).getUsersAndRoles();
+    }
+    function initApp() {
+      document.getElementById('loader').classList.add('d-none');
+      prefetchSupportData();
+      if (restoreSession()) {
+        setLoggedIn(true);
+        if (session.isAdmin) document.getElementById('adminLinks').classList.remove('d-none-view');
+        updateFloorLink();
+        if (session.isAdmin && !session.role) {
+          loadProductionOverview();
+          loadIdleWorkers();
+        } else if (session.role) {
+          enterDashboard();
+        } else {
+          routeAfterLogin();
+        }
+      }
     }
 
     function renderRoles() { showTaskPicker(); }
@@ -2009,17 +2020,26 @@
     function startAutoRefresh() {
       if (refreshInterval) clearInterval(refreshInterval);
       refreshInterval = setInterval(() => { 
-        // Don't refresh if a modal is open OR if we are currently submitting data
+        if (document.hidden) return;
         if (!document.querySelector('.modal.show') && !isSubmitting) {
             loadDashboard(true); 
         }
-      }, 30000); 
+      }, 60000); 
     }
     function stopAutoRefresh() { if (refreshInterval) clearInterval(refreshInterval); }
 
+    let dashInFlight = false;
     function loadDashboard(silent = false) {
+      if (dashInFlight && silent) return;
+      dashInFlight = true;
       if(!silent) document.getElementById('container-available').innerHTML = '<div class="spinner-border"></div>';
+      if (session.name) {
+        google.script.run.withSuccessHandler(notice => {
+          if (notice && notice.resumedOrder) showSwitchBanner(notice);
+        }).popWorkerNotice(session.name);
+      }
       google.script.run.withSuccessHandler(orders => {
+        dashInFlight = false;
         appData.currentOrders = orders; // Cache orders for the modal
         
         // 1. Only Siya can see the Powder Coating List Button
@@ -2215,10 +2235,7 @@
         });
 
         filterDashboard(); 
-        google.script.run.withSuccessHandler(notice => {
-          if (notice && notice.resumedOrder) showSwitchBanner(notice);
-        }).popWorkerNotice(session.name);
-      }).getOrdersForRole(session.role, session.name);
+      }).withFailureHandler(() => { dashInFlight = false; }).getOrdersForRole(session.role, session.name);
     }
     
     function continueToStartModal() {
@@ -2467,6 +2484,9 @@
     }
 
 function openSteelModal() {
+      ensureSteelProfiles(() => openSteelModalReady());
+    }
+    function openSteelModalReady() {
       // Reset inputs
       document.getElementById('steelSizeInput').value = '';
       const customInput = document.getElementById('steelCustomProfile');
@@ -2571,6 +2591,9 @@ function openSteelModal() {
     }
 
     function openWelderSteelModal() {
+      ensureUsers(() => ensureSteelProfiles(() => openWelderSteelModalReady()));
+    }
+    function openWelderSteelModalReady() {
       // 1. Reset Form & Disable Order Select while loading
       const orderSelect = document.getElementById('wsOrderSelect');
       orderSelect.innerHTML = '<option value="">-- Loading Welding Orders... --</option>';
@@ -2584,7 +2607,9 @@ function openSteelModal() {
       document.getElementById('wsSizeInput').value = '';
 
       // 2. Populate Welders List
-      const welders = appData.users.filter(u => u.role === 'Welding');
+      const welders = appData.users.filter(u =>
+        u.role === 'Welding' || (u.tasks && u.tasks.indexOf('Welding') !== -1) || /weld/i.test(u.role || '')
+      );
       welders.forEach(w => {
           document.getElementById('wsWorkerSelect').innerHTML += `<option value="${w.name}">${w.name}</option>`;
       });

--- a/studio-delta-production/index.html
+++ b/studio-delta-production/index.html
@@ -1130,17 +1130,17 @@
       <p class="text-muted">A standard day is the 07:45–15:45 shift minus the 12:00–12:30 break (7.5 hours). Time beyond that is overtime. Overnight jobs are split by calendar day.</p>
       <div class="row g-2 mb-3">
         <div class="col-md-3">
-          <select id="activityPeriod" class="form-select border-dark" onchange="loadActivityReport()">
+          <select id="activityPeriod" class="form-select border-dark" onchange="scheduleActivityReport()">
             <option value="day">Daily</option>
             <option value="week">Weekly</option>
             <option value="month">Monthly</option>
           </select>
         </div>
         <div class="col-md-3">
-          <input type="date" id="activityDate" class="form-control border-dark" onchange="loadActivityReport()">
+          <input type="date" id="activityDate" class="form-control border-dark" onchange="scheduleActivityReport()">
         </div>
         <div class="col-md-3">
-          <select id="activityWorker" class="form-select border-dark" onchange="loadActivityReport()">
+          <select id="activityWorker" class="form-select border-dark" onchange="scheduleActivityReport()">
             <option value="">All workers</option>
           </select>
         </div>
@@ -4871,14 +4871,26 @@ function openSteelModal() {
       }).assignIndirectTask(worker, task, session.name);
     }
 
+    let activityLoadTimer = null;
+    let fillingActivityWorkers = false;
+    function todayInputDate() {
+      const d = new Date();
+      const m = String(d.getMonth() + 1).padStart(2, '0');
+      const day = String(d.getDate()).padStart(2, '0');
+      return d.getFullYear() + '-' + m + '-' + day;
+    }
+    function scheduleActivityReport() {
+      if (fillingActivityWorkers) return;
+      clearTimeout(activityLoadTimer);
+      activityLoadTimer = setTimeout(loadActivityReport, 150);
+    }
     function loadActivityReport() {
       navTo('view-admin-activity');
       const periodEl = document.getElementById('activityPeriod');
       const dateEl = document.getElementById('activityDate');
       const workerEl = document.getElementById('activityWorker');
       if (dateEl && !dateEl.value) {
-        const d = new Date();
-        dateEl.value = d.toISOString().slice(0,10);
+        dateEl.value = todayInputDate();
       }
       const period = periodEl ? periodEl.value : 'day';
       const refMs = dateEl && dateEl.value ? new Date(dateEl.value + 'T12:00:00').getTime() : Date.now();
@@ -4902,7 +4914,9 @@ function openSteelModal() {
         Object.keys(names).sort().forEach(n => {
           html += '<option value="' + n + '"' + (n === current ? ' selected' : '') + '>' + n + '</option>';
         });
+        fillingActivityWorkers = true;
         workerEl.innerHTML = html;
+        fillingActivityWorkers = false;
       }
       let regular = 0, ot = 0, overDays = 0;
       (data.workers || []).forEach(w => {

--- a/studio-delta-production/index.html
+++ b/studio-delta-production/index.html
@@ -2361,7 +2361,7 @@
       if (st === 'ready for assembly' && session.role === 'Assembly') {
         return `<div class="d-flex gap-2 position-relative w-100 flex-wrap" style="z-index: 10;">${start('ASSEMBLE', 'Assembly', 'btn-primary')}${start('PAINT PREP', 'Paint Preparation', 'btn-outline-dark')}</div>`;
       }
-      if (st === 'ready for assembly' && session.role === 'Paint Preparation') {
+      if (st === 'ready for assembly' && (session.role === 'Paint Preparation' || session.role === 'Painting')) {
         return start('START PAINT PREP', 'Paint Preparation');
       }
       return start('START', startTaskForOrder(o));

--- a/studio-delta-production/index.html
+++ b/studio-delta-production/index.html
@@ -1127,7 +1127,7 @@
     
     <div id="view-admin-activity" class="view-section container d-none-view">
       <h2 class="brand-font mb-3">Employee Activity</h2>
-      <p class="text-muted">A standard day is 8 hours. Time beyond that is overtime.</p>
+      <p class="text-muted">A standard day is the 07:45–15:45 shift minus the 12:00–12:30 break (7.5 hours). Time beyond that is overtime. Overnight jobs are split by calendar day.</p>
       <div class="row g-2 mb-3">
         <div class="col-md-3">
           <select id="activityPeriod" class="form-select border-dark" onchange="loadActivityReport()">
@@ -3161,13 +3161,13 @@ function openSteelModal() {
         let day = current.getDay();
         if (day === 0 || day === 6) {
           current.setDate(current.getDate() + 1);
-          current.setHours(7, 30, 0, 0);
+          current.setHours(7, 45, 0, 0);
           continue;
         }
         
-        let shiftStart = new Date(current); shiftStart.setHours(7, 30, 0, 0);
+        let shiftStart = new Date(current); shiftStart.setHours(7, 45, 0, 0);
         let lunchStart = new Date(current); lunchStart.setHours(12, 0, 0, 0);
-        let lunchEnd   = new Date(current); lunchEnd.setHours(13, 0, 0, 0);
+        let lunchEnd   = new Date(current); lunchEnd.setHours(12, 30, 0, 0);
         let shiftEnd   = new Date(current); shiftEnd.setHours(15, 45, 0, 0);
         
         let windowStart = (current > shiftStart) ? current : shiftStart;
@@ -3184,7 +3184,7 @@ function openSteelModal() {
         if (end < shiftEnd) break; 
         else { 
             current.setDate(current.getDate() + 1); 
-            current.setHours(7, 30, 0, 0); 
+            current.setHours(7, 45, 0, 0); 
         }
       }
       return totalMinutes;
@@ -3194,6 +3194,14 @@ function openSteelModal() {
       let h = Math.floor(totalMins / 60);
       let m = Math.floor(totalMins % 60);
       return (h < 10 ? "0"+h : h) + ":" + (m < 10 ? "0"+m : m);
+    }
+
+    function formatClock(ms) {
+      if (!ms) return '';
+      const d = new Date(ms);
+      const h = d.getHours();
+      const m = d.getMinutes();
+      return (h < 10 ? '0' : '') + h + ':' + (m < 10 ? '0' : '') + m;
     }
 
     function startLiveTimers() {
@@ -4826,7 +4834,9 @@ function openSteelModal() {
         html += `<div class="small text-muted mb-1">What they did</div><ul class="mb-0">`;
         (w.tasks || []).slice(0, 40).forEach(task => {
           const kind = task.entryType === 'indirect' ? 'Non-order' : (task.order || '');
-          html += `<li><strong>${task.task}</strong> · ${kind} · ${formatDuration(task.minutes)}${task.end ? '' : ' (running)'}</li>`;
+          const when = task.date ? ' · ' + task.date : '';
+          const clock = task.start ? (' · ' + formatClock(task.start) + '–' + (task.end ? formatClock(task.end) : 'now')) : '';
+          html += `<li><strong>${task.task}</strong> · ${kind}${when}${clock} · ${formatDuration(task.minutes)}${task.end ? '' : ' (running)'}</li>`;
         });
         html += `</ul></div>`;
       });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Studio Delta Production lives in `studio-delta-production/` (not the Chabies website at the repo root). Paste `Code.gs` and `index.html` into the existing Apps Script project. The HTML file must be named `index`.

## Pause and switch reasons

Hours are no longer one start-minus-end total. Each work stretch is kept, including overnight pauses.

Pausing, or leaving a running order to start/resume another, requires a reason:

- **No materials**
- **Touch up** (must enter the order number)
- **Other** (must type why)

Activity shows each bout with date, clock times, minutes, and the pause reason.

## Switch or work together

Everyone who already has an order running, then taps another order (or Resume), gets two choices:

- **Switch from A to B** — pause A (with a reason) and start/resume B
- **Work on A and B** — one clock, time split across the orders (Together badge). **Work this order only** leaves the batch

This is for every role, not only same-product assembly. Same-product assembly can still start matching orders together from Available.

## Paint preparation and painting

From **Ready for Assembly**, assemblers can **Assemble** or **Paint prep**. Painters (Users task `Painting`) also see those orders and can **Start paint prep** — they do not need a separate Paint Preparation task.

1. Paint prep finish → **Ready for Painting**
2. Painters see those orders and start **Painting**
3. Painting finish → **Ready for Assembly**
4. Assemblers then assemble as normal

Orders that do not need paint still go straight to Assembly.

## Employee Activity: overnight jobs split by day

A session that crosses midnight is no longer dumped onto the end date. Hours are split per Johannesburg calendar day against the shift calendar.

Example: started yesterday 14:00, ended today 10:00

- Yesterday: 14:00–15:45 (1h 45m)
- Today: 07:45–10:00 (2h 15m)

Time between 15:45 and 07:45 is not paid (people go home; the log can stay open).

Changing the Activity date no longer reloads the whole log twice. It reads only the needed columns, skips rows outside that day/week/month, and caches the result.

## Workers hour log: same per-day split

Admin → **Workers** used to show one row per production-log entry, so an overnight weld looked like start 14:49 / end 09:50 on the start date, with a single duration.

It now uses the same calendar-day split as Activity:

- One table row per Johannesburg day
- Start/end clipped to that day’s paid window (07:45–15:45, lunch 12:00–12:30)
- Weekly totals (Total Hours, Avg / Order, comparison chart) count minutes on the day they were worked

So S260190 would show as 8/13 14:49–15:45 and 8/14 07:45–09:50, instead of one mixed row on 8/13.

## Shift calendar

- Start **07:45**, end **15:45**
- Break **12:00–12:30** (30 minutes)
- Paid day **7.5 hours / 450 minutes**. Minutes beyond that on a calendar day are overtime.
- Idle alerts only fire on weekdays during 07:45–15:45.

## Speed

Floor boards read only the **latest log rows**, not the whole history. Start / pause / finish reuse that same slice. Order list + switch notices load in **one** round trip. Login no longer kicks off extra steel/user/backboard reads. Pause timestamps are written in one sheet update.

## Idle alerts (no email)

Admin and QC who currently have the app open get a **popup modal** listing idle people so they can assign an indirect task. Tap Later to dismiss that set until someone new goes idle.

## Login

Every page load shows the **login screen first**. The last session is not restored from the tablet.

## Backboard on QC

Assembly and Final QC must log **which backboard was used**, the same way plate/profile cutting logs steel.

## Floor time rules

One running clock per person, same-product batch splits, plate-ready auto-switch for welders, idle alerts, and admin **Activity** (daily / weekly / monthly).

## Deploy

1. Paste the two files into Apps Script.
2. Open once and log in (idle trigger + Tasks column header are created in the background).
3. Fill Users column D, e.g. `Welding, Tagging`. Painters need `Painting`.
4. Optionally fill the `Backboards` sheet the same way as `Steel_Profiles`.
5. Confirm timezone `Africa/Johannesburg`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8673ef8e-0bc4-4585-bf05-c801975eef3b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8673ef8e-0bc4-4585-bf05-c801975eef3b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

